### PR TITLE
Add support for Ethernet network configuration (DHCP / Static IPv4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,26 @@
 
 [![NPM](https://nodei.co/npm/iobroker.telemetry.png?downloads=true)](https://nodei.co/npm/iobroker.wireless-settings/)
 
-## Adapter for Wi-Fi and wireless settings on Raspberry Pi
+## Adapter for Wi-Fi and Ethernet settings on Raspberry Pi / Linux
 
-This adapter can set up the wireless on Raspberry Pi. It can be used to connect or disconnect from wireless networks.
+This fork can configure network interfaces managed by NetworkManager.
 
-**Tested only on Raspberry Pi 5**
+### Supported functions
+
+- Connect and disconnect Wi-Fi networks
+- Show current interface information (IPv4/IPv6, gateway, DNS)
+- Change Ethernet IPv4 settings
+- Change IPv4 settings of active Wi-Fi profiles
+- Switch between DHCP and static IPv4 configuration
+- Configure subnet mask/prefix, gateway and DNS servers
+
+**Tested logic is based on `nmcli` / NetworkManager.**
 
 ## Required permissions
 
-This adapter assumes that `iobroker` user may execute the following commands:
+This adapter assumes that the `iobroker` user may execute the following command:
 
--   `/usr/bin/nmcli`
+- `/usr/bin/nmcli`
 
 You can add the rights by calling:
 
@@ -29,6 +38,12 @@ You can add the rights by calling:
 sudo chmod +x /opt/iobroker/node_modules/iobroker.wireless-settings/wlan_rights.sh
 sudo /opt/iobroker/node_modules/iobroker.wireless-settings/wlan_rights.sh
 ```
+
+## Notes
+
+- Applying new network settings can briefly interrupt the current Admin connection.
+- When the device IP changes, reopen ioBroker Admin with the new address.
+- For Ethernet interfaces without an existing profile, the adapter creates a dedicated NetworkManager profile automatically.
 
 <!--
 	Placeholder for the next version (at the beginning of the line):
@@ -38,32 +53,34 @@ sudo /opt/iobroker/node_modules/iobroker.wireless-settings/wlan_rights.sh
 ## Changelog
 ### **WORK IN PROGRESS**
 
--   (@GermanBluefox) Small layout changes
+- Added editable Ethernet and IPv4 settings in the Admin UI
+- Added DHCP/static IPv4 switching with subnet, gateway and DNS handling
+- Improved command execution by using argument-based process calls instead of raw shell strings
 
 ### 1.0.2 (2024-10-04)
 
--   (@GermanBluefox) Updated for raspberry 5
--   (@GermanBluefox) Change name to "wireless-settings"
+- (@GermanBluefox) Updated for raspberry 5
+- (@GermanBluefox) Change name to "wireless-settings"
 
 ### 0.4.0 (2024-10-03)
 
--   (@GermanBluefox) Change name to "network-settings"
+- (@GermanBluefox) Change name to "network-settings"
 
 ### 0.3.0 (2023-06-27)
 
--   (@GermanBluefox) Change name to "network-settings"
+- (@GermanBluefox) Change name to "network-settings"
 
 ### 0.2.2 (2023-06-27)
 
--   (@GermanBluefox) Updated the GUI to the latest version
+- (@GermanBluefox) Updated the GUI to the latest version
 
 ### 0.1.0 (2021-01-18)
 
--   (ioBroker) fixed build scripts
+- (ioBroker) fixed build scripts
 
 ### 0.0.1 (2021-01-18)
 
--   (ioBroker) initial release
+- (ioBroker) initial release
 
 ## License
 

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, shrink-to-fit=no" />
+    <meta name="theme-color" content="#f5f7fb" />
+    <meta name="color-scheme" content="light dark" />
     <link rel="shortcut icon" href="./favicon.ico" />
     <link rel="manifest" href="./manifest.json" />
     <link rel="stylesheet" href="./network-admin.css" />

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -1,1 +1,49 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"/><link rel="shortcut icon" href="./favicon.ico"/><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/><meta name="theme-color" content="#000000"/><link rel="manifest" href="./manifest.json"/><script type="text/javascript" onerror="setTimeout(function(){window.location.reload()}, 5000)" src="./lib/js/socket.io.js"></script><title>iobroker.network</title><script defer="defer" src="./static/js/main.6614f37e.js"></script><link href="./static/css/main.5e10cad4.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div></body></html>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <link rel="manifest" href="./manifest.json" />
+    <link rel="stylesheet" href="./network-admin.css" />
+    <title>ioBroker.network-settings</title>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="./network-admin.js"></script>
+    <script>
+        (function () {
+            const script = document.createElement('script');
+            const parts = (window.location.search || '').replace(/^\?/, '').split('&');
+            const query = {};
+            parts.forEach(item => {
+                const [name, val] = item.split('=');
+                if (!name) {
+                    return;
+                }
+                query[decodeURIComponent(name)] = val !== undefined ? decodeURIComponent(val) : true;
+            });
+            script.onload = function () {
+                if (typeof window.initializeWirelessSettingsAdmin === 'function') {
+                    window.initializeWirelessSettingsAdmin();
+                }
+            };
+            script.onerror = function () {
+                document.getElementById('root').innerHTML = '<div style="padding:16px;font-family:sans-serif;">socket.io konnte nicht geladen werden.</div>';
+            };
+            script.src =
+                window.location.port === '3000'
+                    ? window.location.protocol +
+                      '//' +
+                      (query.host || window.location.hostname) +
+                      ':' +
+                      (query.port || 8081) +
+                      '/lib/js/socket.io.js'
+                    : '../../lib/js/socket.io.js';
+            document.head.appendChild(script);
+        })();
+    </script>
+</body>
+</html>

--- a/admin/manifest.json
+++ b/admin/manifest.json
@@ -10,6 +10,6 @@
     ],
     "start_url": ".",
     "display": "standalone",
-    "theme_color": "#000000",
-    "background_color": "#ffffff"
+    "theme_color": "#f5f7fb",
+    "background_color": "#f5f7fb"
 }

--- a/admin/network-admin.css
+++ b/admin/network-admin.css
@@ -11,11 +11,33 @@
     --success: #2e7d32;
     --warning: #b26a00;
     --danger: #b00020;
+    --overlay: rgba(0, 0, 0, 0.45);
+    --focus-ring: 0 0 0 3px rgba(63, 81, 181, 0.18);
     --shadow: 0 8px 24px rgba(22, 33, 72, 0.08);
+    --radius-card: 16px;
+    --radius-field: 12px;
+    --app-padding: clamp(12px, 2vw + 8px, 24px);
+}
+
+:root[data-theme='dark'] {
+    --bg: #10131a;
+    --surface: #171c25;
+    --surface-2: #1f2531;
+    --border: #2c3444;
+    --text: #edf2ff;
+    --muted: #a8b2c8;
+    --primary: #6f86ff;
+    --primary-contrast: #0d1324;
+    --success: #69c36f;
+    --warning: #ffb74d;
+    --danger: #ff8a80;
+    --overlay: rgba(0, 0, 0, 0.6);
+    --focus-ring: 0 0 0 3px rgba(111, 134, 255, 0.22);
+    --shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme='light']) {
         --bg: #10131a;
         --surface: #171c25;
         --surface-2: #1f2531;
@@ -27,6 +49,8 @@
         --success: #69c36f;
         --warning: #ffb74d;
         --danger: #ff8a80;
+        --overlay: rgba(0, 0, 0, 0.6);
+        --focus-ring: 0 0 0 3px rgba(111, 134, 255, 0.22);
         --shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
     }
 }
@@ -39,6 +63,7 @@ html,
 body {
     margin: 0;
     padding: 0;
+    min-height: 100%;
     background: var(--bg);
     color: var(--text);
     font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -46,6 +71,8 @@ body {
 
 body {
     min-height: 100vh;
+    line-height: 1.45;
+    overflow-x: hidden;
 }
 
 button,
@@ -53,6 +80,14 @@ input,
 textarea,
 select {
     font: inherit;
+}
+
+button,
+input,
+textarea,
+select,
+a {
+    -webkit-tap-highlight-color: transparent;
 }
 
 button {
@@ -64,14 +99,29 @@ button:disabled {
     cursor: not-allowed;
 }
 
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+img,
+svg,
+canvas {
+    max-width: 100%;
+}
+
 .hidden {
     display: none !important;
 }
 
 .app {
-    max-width: 1380px;
+    width: min(100%, 1440px);
     margin: 0 auto;
-    padding: 20px;
+    padding: var(--app-padding);
+    padding-bottom: max(var(--app-padding), env(safe-area-inset-bottom));
 }
 
 .topbar {
@@ -87,33 +137,42 @@ button:disabled {
     display: flex;
     flex-direction: column;
     gap: 4px;
+    min-width: 0;
 }
 
 .title-group h1 {
     margin: 0;
-    font-size: 1.6rem;
+    font-size: clamp(1.35rem, 1rem + 1.1vw, 1.8rem);
     line-height: 1.2;
+    overflow-wrap: anywhere;
 }
 
 .subtitle {
     color: var(--muted);
     font-size: 0.95rem;
+    overflow-wrap: anywhere;
 }
 
 .top-actions {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 10px;
     flex-wrap: wrap;
 }
 
 .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 42px;
     border: 1px solid var(--border);
     border-radius: 999px;
     padding: 7px 12px;
     background: var(--surface);
     color: var(--muted);
     box-shadow: var(--shadow);
+    text-align: center;
 }
 
 .badge.ok {
@@ -125,12 +184,26 @@ button:disabled {
 }
 
 .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 42px;
+    min-width: 0;
     border: 1px solid var(--border);
     border-radius: 10px;
     background: var(--surface);
     color: var(--text);
     padding: 10px 14px;
     box-shadow: var(--shadow);
+    transition:
+        background-color 0.18s ease,
+        border-color 0.18s ease,
+        transform 0.18s ease,
+        box-shadow 0.18s ease;
+}
+
+.btn:hover:not(:disabled) {
+    transform: translateY(-1px);
 }
 
 .btn.primary {
@@ -167,6 +240,10 @@ button:disabled {
 }
 
 .tab-btn {
+    display: inline-flex;
+    align-items: center;
+    min-height: 42px;
+    max-width: 100%;
     padding: 10px 14px;
     border-radius: 999px;
     border: 1px solid var(--border);
@@ -188,13 +265,15 @@ button:disabled {
 
 .layout {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
     gap: 16px;
+    align-items: start;
 }
 
 .card {
+    min-width: 0;
     border: 1px solid var(--border);
-    border-radius: 16px;
+    border-radius: var(--radius-card);
     background: var(--surface);
     box-shadow: var(--shadow);
     padding: 16px;
@@ -203,11 +282,12 @@ button:disabled {
 .card h2,
 .card h3 {
     margin: 0 0 12px;
+    overflow-wrap: anywhere;
 }
 
 .grid-fields {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 10px;
 }
 
@@ -215,6 +295,7 @@ button:disabled {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    min-width: 0;
 }
 
 .field label {
@@ -225,11 +306,16 @@ button:disabled {
 .field input,
 .field textarea {
     width: 100%;
-    border-radius: 10px;
+    border-radius: var(--radius-field);
     border: 1px solid var(--border);
     background: var(--surface-2);
     color: var(--text);
     padding: 10px 12px;
+}
+
+.field textarea {
+    min-height: 112px;
+    resize: vertical;
 }
 
 .field input[disabled],
@@ -252,6 +338,7 @@ button:disabled {
 .switch {
     position: relative;
     display: inline-flex;
+    flex: 0 0 auto;
     width: 52px;
     height: 30px;
 }
@@ -314,12 +401,12 @@ button:disabled {
 
 .wifi-item {
     display: flex;
-    gap: 10px;
+    gap: 12px;
     align-items: center;
     justify-content: space-between;
     border: 1px solid var(--border);
     border-radius: 12px;
-    padding: 10px 12px;
+    padding: 12px;
     background: var(--surface-2);
 }
 
@@ -328,6 +415,7 @@ button:disabled {
     flex-direction: column;
     gap: 4px;
     min-width: 0;
+    flex: 1 1 auto;
 }
 
 .wifi-name {
@@ -338,6 +426,7 @@ button:disabled {
 .wifi-meta {
     color: var(--muted);
     font-size: 0.92rem;
+    overflow-wrap: anywhere;
 }
 
 .wifi-actions {
@@ -345,6 +434,7 @@ button:disabled {
     gap: 8px;
     flex-wrap: wrap;
     justify-content: flex-end;
+    flex: 0 1 auto;
 }
 
 .empty {
@@ -354,9 +444,9 @@ button:disabled {
 .toast {
     position: fixed;
     right: 16px;
-    bottom: 16px;
+    bottom: max(16px, env(safe-area-inset-bottom));
     min-width: 280px;
-    max-width: 460px;
+    width: min(460px, calc(100vw - 32px));
     padding: 12px 14px;
     border-radius: 12px;
     background: var(--surface);
@@ -374,7 +464,7 @@ button:disabled {
 .modal-backdrop {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--overlay);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -405,6 +495,115 @@ button:disabled {
     animation: spin 0.8s linear infinite;
     vertical-align: text-bottom;
     margin-right: 8px;
+}
+
+@media (max-width: 1080px) {
+    .layout {
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+    }
+}
+
+@media (max-width: 720px) {
+    .topbar {
+        align-items: stretch;
+    }
+
+    .top-actions {
+        width: 100%;
+        justify-content: stretch;
+    }
+
+    .top-actions > * {
+        flex: 1 1 100%;
+    }
+
+    .tabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overscroll-behavior-x: contain;
+        scrollbar-width: thin;
+        padding-bottom: 4px;
+        margin-inline: calc(var(--app-padding) * -1);
+        padding-inline: var(--app-padding);
+    }
+
+    .tab-btn {
+        flex: 0 0 auto;
+        white-space: nowrap;
+    }
+
+    .card {
+        padding: 14px;
+        border-radius: 14px;
+    }
+
+    .actions {
+        flex-direction: column;
+    }
+
+    .actions .btn,
+    .wifi-actions .btn {
+        width: 100%;
+    }
+
+    .wifi-item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .wifi-actions {
+        width: 100%;
+        justify-content: stretch;
+    }
+
+    .toast {
+        left: 16px;
+        right: 16px;
+        width: auto;
+        min-width: 0;
+    }
+
+    .modal-backdrop {
+        align-items: flex-end;
+        padding: 12px;
+    }
+
+    .modal {
+        width: 100%;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+}
+
+@media (max-width: 520px) {
+    .app {
+        --app-padding: 12px;
+    }
+
+    .title-group h1 {
+        font-size: 1.3rem;
+    }
+
+    .subtitle,
+    .field label,
+    .wifi-meta {
+        font-size: 0.9rem;
+    }
+
+    .inline-switch {
+        align-items: flex-start;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }
 
 @keyframes spin {

--- a/admin/network-admin.css
+++ b/admin/network-admin.css
@@ -1,0 +1,414 @@
+:root {
+    color-scheme: light dark;
+    --bg: #f5f7fb;
+    --surface: #ffffff;
+    --surface-2: #f0f3f8;
+    --border: #d8deea;
+    --text: #1d2433;
+    --muted: #63708a;
+    --primary: #3f51b5;
+    --primary-contrast: #ffffff;
+    --success: #2e7d32;
+    --warning: #b26a00;
+    --danger: #b00020;
+    --shadow: 0 8px 24px rgba(22, 33, 72, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #10131a;
+        --surface: #171c25;
+        --surface-2: #1f2531;
+        --border: #2c3444;
+        --text: #edf2ff;
+        --muted: #a8b2c8;
+        --primary: #6f86ff;
+        --primary-contrast: #0d1324;
+        --success: #69c36f;
+        --warning: #ffb74d;
+        --danger: #ff8a80;
+        --shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+    }
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+    min-height: 100vh;
+}
+
+button,
+input,
+textarea,
+select {
+    font: inherit;
+}
+
+button {
+    cursor: pointer;
+}
+
+button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.app {
+    max-width: 1380px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.topbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.title-group h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    line-height: 1.2;
+}
+
+.subtitle {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.top-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.badge {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 7px 12px;
+    background: var(--surface);
+    color: var(--muted);
+    box-shadow: var(--shadow);
+}
+
+.badge.ok {
+    color: var(--success);
+}
+
+.badge.err {
+    color: var(--danger);
+}
+
+.btn {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    padding: 10px 14px;
+    box-shadow: var(--shadow);
+}
+
+.btn.primary {
+    border-color: var(--primary);
+    background: var(--primary);
+    color: var(--primary-contrast);
+}
+
+.btn.ghost {
+    background: transparent;
+    box-shadow: none;
+}
+
+.notice {
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--warning);
+    background: var(--surface);
+    border-radius: 12px;
+    padding: 12px 14px;
+    margin-bottom: 16px;
+    color: var(--muted);
+}
+
+.notice.error {
+    border-left-color: var(--danger);
+    color: var(--danger);
+}
+
+.tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+.tab-btn {
+    padding: 10px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    box-shadow: var(--shadow);
+}
+
+.tab-btn.active {
+    border-color: var(--primary);
+    background: var(--primary);
+    color: var(--primary-contrast);
+}
+
+.tab-status {
+    opacity: 0.85;
+    margin-right: 8px;
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 16px;
+}
+
+.card {
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+    padding: 16px;
+}
+
+.card h2,
+.card h3 {
+    margin: 0 0 12px;
+}
+
+.grid-fields {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.field label {
+    color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.field input,
+.field textarea {
+    width: 100%;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
+    padding: 10px 12px;
+}
+
+.field input[disabled],
+.field textarea[disabled] {
+    opacity: 0.75;
+}
+
+.field small {
+    color: var(--muted);
+}
+
+.inline-switch {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 0 6px;
+}
+
+.switch {
+    position: relative;
+    display: inline-flex;
+    width: 52px;
+    height: 30px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    inset: 0;
+    border-radius: 999px;
+    background: var(--border);
+    transition: 0.2s ease;
+}
+
+.slider::before {
+    content: '';
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    left: 3px;
+    top: 3px;
+    border-radius: 50%;
+    background: #fff;
+    transition: 0.2s ease;
+}
+
+.switch input:checked + .slider {
+    background: var(--primary);
+}
+
+.switch input:checked + .slider::before {
+    transform: translateX(22px);
+}
+
+.actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+}
+
+.warning {
+    margin-top: 16px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--muted);
+}
+
+.wifi-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.wifi-item {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 10px 12px;
+    background: var(--surface-2);
+}
+
+.wifi-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.wifi-name {
+    font-weight: 600;
+    word-break: break-word;
+}
+
+.wifi-meta {
+    color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.wifi-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.empty {
+    color: var(--muted);
+}
+
+.toast {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    min-width: 280px;
+    max-width: 460px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    color: var(--text);
+    z-index: 50;
+}
+
+.toast.error {
+    border-color: var(--danger);
+    color: var(--danger);
+}
+
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    z-index: 100;
+}
+
+.modal {
+    width: min(420px, 100%);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+    padding: 16px;
+}
+
+.modal h3 {
+    margin-top: 0;
+}
+
+.spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    animation: spin 0.8s linear infinite;
+    vertical-align: text-bottom;
+    margin-right: 8px;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/admin/network-admin.js
+++ b/admin/network-admin.js
@@ -121,9 +121,45 @@
         toast: '',
         toastError: false,
         passwordTarget: null,
+        theme: 'light',
     };
 
     let socket;
+    let systemThemeMedia;
+
+    function resolveSystemTheme() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    function updateThemeColorMeta(theme) {
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.setAttribute('content', theme === 'dark' ? '#10131a' : '#f5f7fb');
+        }
+    }
+
+    function applySystemTheme() {
+        state.theme = resolveSystemTheme();
+        document.documentElement.dataset.theme = state.theme;
+        document.documentElement.style.colorScheme = state.theme;
+        updateThemeColorMeta(state.theme);
+    }
+
+    function bindSystemTheme() {
+        if (!window.matchMedia || systemThemeMedia) {
+            return;
+        }
+        systemThemeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+        const handler = () => {
+            applySystemTheme();
+            render();
+        };
+        if (typeof systemThemeMedia.addEventListener === 'function') {
+            systemThemeMedia.addEventListener('change', handler);
+        } else if (typeof systemThemeMedia.addListener === 'function') {
+            systemThemeMedia.addListener(handler);
+        }
+    }
 
     function parseQuery() {
         const result = {};
@@ -528,6 +564,7 @@
     }
 
     function render() {
+        applySystemTheme();
         const root = document.getElementById('root');
         const selected = selectedInterface();
         const edited = editedInterface();
@@ -670,6 +707,23 @@
                 render();
             };
         }
+
+        const modalBackdrop = document.getElementById('wifi-modal-backdrop');
+        if (modalBackdrop) {
+            modalBackdrop.onclick = event => {
+                if (event.target === modalBackdrop) {
+                    state.passwordTarget = null;
+                    render();
+                }
+            };
+        }
+
+        document.onkeydown = event => {
+            if (event.key === 'Escape' && state.passwordTarget) {
+                state.passwordTarget = null;
+                render();
+            }
+        };
     }
 
     function bindInput(id, handler) {
@@ -783,6 +837,8 @@
     }
 
     window.initializeWirelessSettingsAdmin = async function initializeWirelessSettingsAdmin() {
+        applySystemTheme();
+        bindSystemTheme();
         socket = window.io.connect();
         socket.on('connect', () => {
             refreshAll(true).catch(error => setToast(`${t('saveFailed')}: ${error.message || error}`, true));

--- a/admin/network-admin.js
+++ b/admin/network-admin.js
@@ -1,0 +1,796 @@
+(() => {
+    const TEXT = {
+        en: {
+            title: 'Network settings',
+            subtitle: 'Configure Ethernet and WI-FI interfaces on the device',
+            refresh: 'Refresh',
+            adapterRunning: 'Adapter is running',
+            adapterStopped: 'Adapter is not running',
+            noInterfaces: 'No network interfaces detected.',
+            instanceStopped: 'The adapter instance is not running.',
+            loading: 'Loading…',
+            currentValues: 'Current network values',
+            ipv4Config: 'IPv4 configuration',
+            connectionProfile: 'Connection profile',
+            useDhcp: 'Use DHCP',
+            staticIp: 'Static IPv4 address',
+            subnet: 'Subnet mask or prefix',
+            subnetHint: 'Examples: 255.255.255.0 or 24',
+            gateway: 'Default gateway',
+            dnsServers: 'DNS servers',
+            dnsHint: 'One entry per line or separated by commas',
+            apply: 'Apply network settings',
+            reset: 'Reset changes',
+            warning:
+                'Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.',
+            wifiNetworks: 'WI-FI networks',
+            scanWifi: 'Scan WI-FI',
+            disconnect: 'Disconnect',
+            connect: 'Connect',
+            connected: 'connected',
+            notConnected: 'not connected',
+            enterPassword: 'Enter WI-FI password',
+            password: 'WI-FI password',
+            cancel: 'Cancel',
+            submit: 'Apply',
+            interfaceNotEditable: 'This interface cannot be edited with NetworkManager.',
+            wifiNeedsProfile: 'Connect to a WI-FI network first to edit its IP settings.',
+            noWifiFound: 'No WI-FI networks found.',
+            saveFailed: 'Unable to save network settings',
+            profileMissing: 'No editable NetworkManager profile found for this interface.',
+            profileCreating: 'A dedicated Ethernet profile will be created automatically if needed.',
+            noActiveConnection: 'No active connection',
+            status: 'Status',
+            ip4: 'IPv4',
+            ip4Mask: 'IPv4 netmask',
+            ip6: 'IPv6',
+            ip6Mask: 'IPv6 netmask',
+            dnsRecord: 'DNS record',
+            saved: 'Network settings saved. The connection will be reapplied shortly.',
+            busy: 'Processing…',
+        },
+        de: {
+            title: 'Netzwerk-Einstellungen',
+            subtitle: 'Ethernet- und WLAN-Schnittstellen des Geräts konfigurieren',
+            refresh: 'Aktualisieren',
+            adapterRunning: 'Adapter läuft',
+            adapterStopped: 'Adapter läuft nicht',
+            noInterfaces: 'Keine Netzwerkschnittstellen erkannt.',
+            instanceStopped: 'Die Adapter-Instanz läuft nicht.',
+            loading: 'Lade …',
+            currentValues: 'Aktuelle Netzwerkwerte',
+            ipv4Config: 'IPv4-Konfiguration',
+            connectionProfile: 'Verbindungsprofil',
+            useDhcp: 'DHCP verwenden',
+            staticIp: 'Statische IPv4-Adresse',
+            subnet: 'Subnetzmaske oder Präfix',
+            subnetHint: 'Beispiele: 255.255.255.0 oder 24',
+            gateway: 'Standardgateway',
+            dnsServers: 'DNS-Server',
+            dnsHint: 'Ein Eintrag pro Zeile oder durch Kommas getrennt',
+            apply: 'Netzwerkeinstellungen anwenden',
+            reset: 'Änderungen zurücksetzen',
+            warning:
+                'Das Anwenden der Netzwerkeinstellungen kann die aktuelle Verbindung unterbrechen. Wenn sich die IP-Adresse ändert, öffne die Admin-Seite mit der neuen Adresse erneut.',
+            wifiNetworks: 'WLAN-Netzwerke',
+            scanWifi: 'WLAN scannen',
+            disconnect: 'Trennen',
+            connect: 'Verbinden',
+            connected: 'verbunden',
+            notConnected: 'nicht verbunden',
+            enterPassword: 'WLAN-Passwort eingeben',
+            password: 'WLAN-Passwort',
+            cancel: 'Abbrechen',
+            submit: 'Anwenden',
+            interfaceNotEditable: 'Diese Schnittstelle kann nicht über NetworkManager bearbeitet werden.',
+            wifiNeedsProfile: 'Verbinde dich zuerst mit einem WLAN, um dessen IP-Einstellungen zu bearbeiten.',
+            noWifiFound: 'Keine WLAN-Netzwerke gefunden.',
+            saveFailed: 'Netzwerkeinstellungen konnten nicht gespeichert werden',
+            profileMissing: 'Für diese Schnittstelle wurde kein bearbeitbares NetworkManager-Profil gefunden.',
+            profileCreating: 'Falls nötig wird automatisch ein eigenes Ethernet-Profil angelegt.',
+            noActiveConnection: 'Keine aktive Verbindung',
+            status: 'Status',
+            ip4: 'IPv4',
+            ip4Mask: 'IPv4-Netzmaske',
+            ip6: 'IPv6',
+            ip6Mask: 'IPv6-Netzmaske',
+            dnsRecord: 'DNS-Eintrag',
+            saved: 'Netzwerkeinstellungen gespeichert. Die Verbindung wird in Kürze neu angewendet.',
+            busy: 'Verarbeite …',
+        },
+    };
+
+    const lang = (navigator.language || 'en').toLowerCase().startsWith('de') ? 'de' : 'en';
+    const t = key => TEXT[lang][key] || TEXT.en[key] || key;
+
+    const query = parseQuery();
+    const pathParts = window.location.pathname.split('/').filter(Boolean);
+    const adapterName = pathParts[pathParts.length - 2] || 'wireless-settings';
+    const instance = query.instance !== undefined ? parseInt(query.instance, 10) || 0 : parseInt(window.location.search.slice(1), 10) || 0;
+    const adapterInstance = `${adapterName}.${instance}`;
+    const aliveStateId = `system.adapter.${adapterName}.${instance}.alive`;
+
+    const state = {
+        alive: false,
+        loading: false,
+        interfaces: [],
+        edited: {},
+        tab: '',
+        wifi: [],
+        wifiConnection: '',
+        toast: '',
+        toastError: false,
+        passwordTarget: null,
+    };
+
+    let socket;
+
+    function parseQuery() {
+        const result = {};
+        (window.location.search || '')
+            .replace(/^\?/, '')
+            .replace(/#.*$/, '')
+            .split('&')
+            .filter(Boolean)
+            .forEach(item => {
+                const [rawName, rawValue] = item.split('=');
+                result[decodeURIComponent(rawName)] = rawValue === undefined ? true : decodeURIComponent(rawValue);
+            });
+        return result;
+    }
+
+    function clone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+
+    function escapeHtml(value) {
+        return `${value ?? ''}`
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    function normalizeDnsList(value) {
+        if (!value) {
+            return [];
+        }
+        if (Array.isArray(value)) {
+            return value.map(item => `${item}`.trim()).filter(Boolean);
+        }
+        return `${value}`
+            .split(/[\n,;]+/)
+            .map(item => item.trim())
+            .filter(Boolean);
+    }
+
+    function normalizeConfig(interfaceItem) {
+        return JSON.stringify({
+            dhcp: !!interfaceItem?.dhcp,
+            configIp4: `${interfaceItem?.configIp4 || ''}`.trim(),
+            configIp4subnet: `${interfaceItem?.configIp4subnet || ''}`.trim(),
+            configGateway: `${interfaceItem?.configGateway || ''}`.trim(),
+            configDns: normalizeDnsList(interfaceItem?.configDns),
+        });
+    }
+
+    function selectedInterface() {
+        return state.interfaces.find(item => item.iface === state.tab) || null;
+    }
+
+    function editedInterface() {
+        const selected = selectedInterface();
+        if (!selected) {
+            return null;
+        }
+        if (!state.edited[selected.iface]) {
+            state.edited[selected.iface] = clone(selected);
+        }
+        return state.edited[selected.iface];
+    }
+
+    function isDirty(iface) {
+        const original = state.interfaces.find(item => item.iface === iface);
+        const changed = state.edited[iface];
+        if (!original || !changed) {
+            return false;
+        }
+        return normalizeConfig(original) !== normalizeConfig(changed);
+    }
+
+    function setToast(message, isError = false) {
+        state.toast = message;
+        state.toastError = isError;
+        render();
+        if (message) {
+            window.clearTimeout(setToast.timer);
+            setToast.timer = window.setTimeout(() => {
+                state.toast = '';
+                state.toastError = false;
+                render();
+            }, 5000);
+        }
+    }
+
+    async function getStateAsync(id) {
+        return new Promise((resolve, reject) => {
+            socket.emit('getState', id, (error, result) => {
+                if (error) {
+                    reject(new Error(error));
+                } else {
+                    resolve(result);
+                }
+            });
+        });
+    }
+
+    async function sendToAsync(command, message) {
+        return new Promise(resolve => socket.emit('sendTo', adapterInstance, command, message, resolve));
+    }
+
+    function sortInterfaces(interfaces) {
+        const list = [...interfaces];
+        list.sort((a, b) => (`${a.mac}` > `${b.mac}` ? -1 : 1));
+        list.sort((a, b) => (a.type === 'wifi' && b.type === 'wifi' ? 0 : a.type === 'wifi' ? -1 : 1));
+        list.sort((a, b) => (!a.virtual && !b.virtual ? 0 : !a.virtual ? -1 : 1));
+        return list.filter(item => item.ip4 !== '127.0.0.1');
+    }
+
+    function chooseTab() {
+        if (state.interfaces.find(item => item.iface === state.tab)) {
+            return;
+        }
+        const savedTab = window.localStorage.getItem(`network.${instance}.tab`);
+        if (savedTab && state.interfaces.find(item => item.iface === savedTab)) {
+            state.tab = savedTab;
+            return;
+        }
+        if (state.interfaces.find(item => item.iface === 'wlan0')) {
+            state.tab = 'wlan0';
+            return;
+        }
+        const wifi = state.interfaces.find(item => item.type === 'wifi');
+        if (wifi) {
+            state.tab = wifi.iface;
+            return;
+        }
+        state.tab = state.interfaces[0]?.iface || '';
+    }
+
+    async function loadAlive() {
+        try {
+            const alive = await getStateAsync(aliveStateId);
+            state.alive = !!alive?.val;
+        } catch {
+            state.alive = false;
+        }
+    }
+
+    async function loadInterfaces() {
+        const interfaces = (await sendToAsync('interfaces', null)) || [];
+        state.interfaces = sortInterfaces(interfaces);
+        const newEdited = {};
+        for (const iface of state.interfaces) {
+            newEdited[iface.iface] = clone(iface);
+        }
+        state.edited = newEdited;
+        chooseTab();
+        if (state.tab) {
+            window.localStorage.setItem(`network.${instance}.tab`, state.tab);
+        }
+    }
+
+    async function loadWifi() {
+        const selected = selectedInterface();
+        state.wifi = [];
+        state.wifiConnection = '';
+        if (!selected || selected.type !== 'wifi' || !state.alive) {
+            return;
+        }
+        state.wifiConnection = (await sendToAsync('wifiConnection', { iface: selected.iface })) || '';
+        let wifi = (await sendToAsync('wifi', null)) || [];
+        wifi = wifi.filter(item => item.ssid && item.ssid.trim());
+        wifi.sort((a, b) => {
+            const connectedA = a.ssid === state.wifiConnection;
+            const connectedB = b.ssid === state.wifiConnection;
+            if (connectedA) {
+                return -1;
+            }
+            if (connectedB) {
+                return 1;
+            }
+            return b.quality - a.quality;
+        });
+        state.wifi = wifi;
+    }
+
+    async function refreshAll(withWifi = true) {
+        state.loading = true;
+        render();
+        try {
+            await loadAlive();
+            if (state.alive) {
+                await loadInterfaces();
+                if (withWifi) {
+                    await loadWifi();
+                }
+            } else {
+                state.interfaces = [];
+                state.edited = {};
+                state.wifi = [];
+                state.wifiConnection = '';
+            }
+        } catch (error) {
+            setToast(`${t('saveFailed')}: ${error.message || error}`, true);
+        } finally {
+            state.loading = false;
+            render();
+        }
+    }
+
+    async function refreshWifiOnly() {
+        state.loading = true;
+        render();
+        try {
+            await loadWifi();
+        } catch (error) {
+            setToast(`${t('saveFailed')}: ${error.message || error}`, true);
+        } finally {
+            state.loading = false;
+            render();
+        }
+    }
+
+    function statusIcon(status, type) {
+        if (type === 'wifi') {
+            return status === 'connected' ? '📶' : '📡';
+        }
+        return status === 'connected' ? '🔌' : '🧩';
+    }
+
+    function renderTabs() {
+        if (!state.interfaces.length) {
+            return `<div class="notice">${escapeHtml(state.alive ? t('noInterfaces') : t('instanceStopped'))}</div>`;
+        }
+        return `<div class="tabs">${state.interfaces
+            .map(
+                item => `<button class="tab-btn ${item.iface === state.tab ? 'active' : ''}" data-action="select-tab" data-iface="${escapeHtml(item.iface)}">
+                        <span class="tab-status">${statusIcon(item.status, item.type)}</span>
+                        <span>${escapeHtml(item.iface)}</span>
+                    </button>`,
+            )
+            .join('')}</div>`;
+    }
+
+    function renderCurrentValues(selected) {
+        const dns = Array.isArray(selected.dns) ? selected.dns : [];
+        return `
+            <div class="card">
+                <h2>${escapeHtml(t('currentValues'))}</h2>
+                <div class="grid-fields">
+                    <div class="field">
+                        <label>${escapeHtml(t('status'))}</label>
+                        <input value="${escapeHtml(selected.status || '')}" disabled />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('ip4'))}</label>
+                        <input value="${escapeHtml(selected.ip4 || '')}" disabled />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('ip4Mask'))}</label>
+                        <input value="${escapeHtml(selected.ip4subnet || '')}" disabled />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('gateway'))}</label>
+                        <input value="${escapeHtml(selected.gateway || '')}" disabled />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('ip6'))}</label>
+                        <input value="${escapeHtml(selected.ip6 || '')}" disabled />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('ip6Mask'))}</label>
+                        <input value="${escapeHtml(selected.ip6subnet || '')}" disabled />
+                    </div>
+                    ${dns
+                        .map(
+                            (record, index) => `<div class="field">
+                                <label>${escapeHtml(`${t('dnsRecord')} ${index + 1}`)}</label>
+                                <input value="${escapeHtml(record)}" disabled />
+                            </div>`,
+                        )
+                        .join('')}
+                </div>
+            </div>`;
+    }
+
+    function renderConfigEditor(selected, edited) {
+        const dirty = isDirty(selected.iface);
+        const editable = !!edited.editable;
+        const wifiNeedsProfile = edited.type === 'wifi' && !edited.connection;
+        const disableSave = !editable || state.loading || wifiNeedsProfile || (!edited.dhcp && (!edited.configIp4 || !edited.configIp4subnet));
+        return `
+            <div class="card">
+                <h2>${escapeHtml(t('ipv4Config'))}</h2>
+                <div class="grid-fields">
+                    <div class="field">
+                        <label>${escapeHtml(t('connectionProfile'))}</label>
+                        <input value="${escapeHtml(edited.connection || (edited.type === 'ethernet' ? t('profileCreating') : t('noActiveConnection')))}" disabled />
+                    </div>
+                    <div class="inline-switch">
+                        <div>
+                            <strong>${escapeHtml(t('useDhcp'))}</strong>
+                        </div>
+                        <label class="switch">
+                            <input type="checkbox" id="dhcp-toggle" ${edited.dhcp ? 'checked' : ''} ${!editable ? 'disabled' : ''} />
+                            <span class="slider"></span>
+                        </label>
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('staticIp'))}</label>
+                        <input id="config-ip4" value="${escapeHtml(edited.configIp4 || '')}" ${edited.dhcp || !editable ? 'disabled' : ''} />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('subnet'))}</label>
+                        <input id="config-subnet" value="${escapeHtml(edited.configIp4subnet || '')}" ${edited.dhcp || !editable ? 'disabled' : ''} />
+                        <small>${escapeHtml(t('subnetHint'))}</small>
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('gateway'))}</label>
+                        <input id="config-gateway" value="${escapeHtml(edited.configGateway || '')}" ${edited.dhcp || !editable ? 'disabled' : ''} />
+                    </div>
+                    <div class="field">
+                        <label>${escapeHtml(t('dnsServers'))}</label>
+                        <textarea id="config-dns" rows="4" ${!editable ? 'disabled' : ''}>${escapeHtml(
+                            normalizeDnsList(edited.configDns).join('\n'),
+                        )}</textarea>
+                        <small>${escapeHtml(t('dnsHint'))}</small>
+                    </div>
+                </div>
+                ${!editable ? `<div class="notice">${escapeHtml(t('interfaceNotEditable'))}</div>` : ''}
+                ${wifiNeedsProfile ? `<div class="notice">${escapeHtml(t('wifiNeedsProfile'))}</div>` : ''}
+                <div class="actions">
+                    <button class="btn primary" data-action="apply-config" ${!dirty || disableSave ? 'disabled' : ''}>${
+                        state.loading ? `<span class="spinner"></span>${escapeHtml(t('busy'))}` : escapeHtml(t('apply'))
+                    }</button>
+                    <button class="btn" data-action="reset-config" ${!dirty || state.loading ? 'disabled' : ''}>${escapeHtml(t('reset'))}</button>
+                </div>
+                <div class="warning">${escapeHtml(t('warning'))}</div>
+            </div>`;
+    }
+
+    function renderWifi(selected) {
+        if (selected.type !== 'wifi') {
+            return '';
+        }
+        return `
+            <div class="card">
+                <div class="topbar" style="margin-bottom: 12px;">
+                    <div class="title-group">
+                        <h2>${escapeHtml(t('wifiNetworks'))}</h2>
+                        <div class="subtitle">${escapeHtml(state.wifiConnection ? `${state.wifiConnection} ${t('connected')}` : t('notConnected'))}</div>
+                    </div>
+                    <div class="top-actions">
+                        <button class="btn" data-action="scan-wifi" ${state.loading ? 'disabled' : ''}>${escapeHtml(t('scanWifi'))}</button>
+                    </div>
+                </div>
+                <div class="wifi-list">
+                    ${state.wifi.length ? state.wifi.map(item => renderWifiRow(item)).join('') : `<div class="empty">${escapeHtml(t('noWifiFound'))}</div>`}
+                </div>
+            </div>`;
+    }
+
+    function renderWifiRow(network) {
+        const connected = network.ssid === state.wifiConnection;
+        const openNetwork = `${network.security || ''}`.includes('--');
+        const quality = Number(network.quality || 0);
+        const signal = quality > 80 ? '▂▄▆█' : quality > 60 ? '▂▄▆_' : quality > 30 ? '▂▄__' : '▂___';
+        return `
+            <div class="wifi-item">
+                <div class="wifi-info">
+                    <div class="wifi-name">${escapeHtml(network.ssid)} ${connected ? '✅' : ''}</div>
+                    <div class="wifi-meta">${escapeHtml(`${signal}  ${Math.round(quality)}%  •  ${network.speed || ''}  •  CH ${network.channel || ''}  •  ${network.security || '--'}`)}</div>
+                </div>
+                <div class="wifi-actions">
+                    ${connected
+                        ? `<button class="btn" data-action="disconnect-wifi">${escapeHtml(t('disconnect'))}</button>`
+                        : `<button class="btn primary" data-action="connect-wifi" data-ssid="${escapeHtml(network.ssid)}" data-open="${openNetwork}">${escapeHtml(t('connect'))}</button>`}
+                </div>
+            </div>`;
+    }
+
+    function renderModal() {
+        if (!state.passwordTarget) {
+            return '';
+        }
+        return `
+            <div class="modal-backdrop" id="wifi-modal-backdrop">
+                <div class="modal">
+                    <h3>${escapeHtml(t('enterPassword'))}</h3>
+                    <div class="field">
+                        <label>${escapeHtml(t('password'))}</label>
+                        <input id="wifi-password-input" type="password" autocomplete="current-password" />
+                    </div>
+                    <div class="actions">
+                        <button class="btn primary" data-action="confirm-wifi-password">${escapeHtml(t('submit'))}</button>
+                        <button class="btn" data-action="cancel-wifi-password">${escapeHtml(t('cancel'))}</button>
+                    </div>
+                </div>
+            </div>`;
+    }
+
+    function renderToast() {
+        if (!state.toast) {
+            return '';
+        }
+        return `<div class="toast ${state.toastError ? 'error' : ''}">${escapeHtml(state.toast)}</div>`;
+    }
+
+    function render() {
+        const root = document.getElementById('root');
+        const selected = selectedInterface();
+        const edited = editedInterface();
+
+        root.innerHTML = `
+            <div class="app">
+                <div class="topbar">
+                    <div class="title-group">
+                        <h1>${escapeHtml(t('title'))}</h1>
+                        <div class="subtitle">${escapeHtml(t('subtitle'))}</div>
+                    </div>
+                    <div class="top-actions">
+                        <div class="badge ${state.alive ? 'ok' : 'err'}">${escapeHtml(state.alive ? t('adapterRunning') : t('adapterStopped'))}</div>
+                        <button class="btn" data-action="refresh-all" ${state.loading ? 'disabled' : ''}>${escapeHtml(t('refresh'))}</button>
+                    </div>
+                </div>
+                ${state.loading ? `<div class="notice"><span class="spinner"></span>${escapeHtml(t('loading'))}</div>` : ''}
+                ${renderTabs()}
+                ${selected && edited ? `<div class="layout">${renderCurrentValues(selected)}${renderConfigEditor(selected, edited)}${renderWifi(selected)}</div>` : ''}
+                ${renderModal()}
+                ${renderToast()}
+            </div>`;
+
+        attachEvents();
+
+        if (state.passwordTarget) {
+            const input = document.getElementById('wifi-password-input');
+            if (input) {
+                input.focus();
+            }
+        }
+    }
+
+    function attachEvents() {
+        document.querySelectorAll('[data-action="select-tab"]').forEach(button => {
+            button.onclick = async event => {
+                const iface = event.currentTarget.getAttribute('data-iface');
+                state.tab = iface;
+                window.localStorage.setItem(`network.${instance}.tab`, iface);
+                await refreshWifiOnly();
+            };
+        });
+
+        const refreshButton = document.querySelector('[data-action="refresh-all"]');
+        if (refreshButton) {
+            refreshButton.onclick = () => refreshAll(true);
+        }
+
+        const dhcpToggle = document.getElementById('dhcp-toggle');
+        if (dhcpToggle) {
+            dhcpToggle.onchange = event => {
+                const edited = editedInterface();
+                if (!edited) {
+                    return;
+                }
+                edited.dhcp = !!event.target.checked;
+                if (edited.dhcp) {
+                    edited.configIp4 = '';
+                    edited.configIp4subnet = '';
+                    edited.configGateway = '';
+                }
+                render();
+            };
+        }
+
+        bindInput('config-ip4', value => {
+            const edited = editedInterface();
+            if (edited) {
+                edited.configIp4 = value;
+            }
+        });
+        bindInput('config-subnet', value => {
+            const edited = editedInterface();
+            if (edited) {
+                edited.configIp4subnet = value;
+            }
+        });
+        bindInput('config-gateway', value => {
+            const edited = editedInterface();
+            if (edited) {
+                edited.configGateway = value;
+            }
+        });
+        bindInput('config-dns', value => {
+            const edited = editedInterface();
+            if (edited) {
+                edited.configDns = normalizeDnsList(value);
+            }
+        });
+
+        const applyButton = document.querySelector('[data-action="apply-config"]');
+        if (applyButton) {
+            applyButton.onclick = () => applyConfig();
+        }
+        const resetButton = document.querySelector('[data-action="reset-config"]');
+        if (resetButton) {
+            resetButton.onclick = () => resetConfig();
+        }
+        const scanButton = document.querySelector('[data-action="scan-wifi"]');
+        if (scanButton) {
+            scanButton.onclick = () => refreshWifiOnly();
+        }
+
+        document.querySelectorAll('[data-action="connect-wifi"]').forEach(button => {
+            button.onclick = async event => {
+                const ssid = event.currentTarget.getAttribute('data-ssid');
+                const openNetwork = event.currentTarget.getAttribute('data-open') === 'true';
+                if (openNetwork) {
+                    await connectWifi(ssid, '');
+                } else {
+                    state.passwordTarget = { ssid };
+                    render();
+                }
+            };
+        });
+
+        const disconnectButton = document.querySelector('[data-action="disconnect-wifi"]');
+        if (disconnectButton) {
+            disconnectButton.onclick = () => disconnectWifi();
+        }
+
+        const confirmPassword = document.querySelector('[data-action="confirm-wifi-password"]');
+        if (confirmPassword) {
+            confirmPassword.onclick = async () => {
+                const input = document.getElementById('wifi-password-input');
+                const password = input ? input.value : '';
+                const target = state.passwordTarget;
+                state.passwordTarget = null;
+                render();
+                if (target?.ssid) {
+                    await connectWifi(target.ssid, password);
+                }
+            };
+        }
+
+        const cancelPassword = document.querySelector('[data-action="cancel-wifi-password"]');
+        if (cancelPassword) {
+            cancelPassword.onclick = () => {
+                state.passwordTarget = null;
+                render();
+            };
+        }
+    }
+
+    function bindInput(id, handler) {
+        const input = document.getElementById(id);
+        if (!input) {
+            return;
+        }
+        input.oninput = event => {
+            handler(event.target.value);
+            const selected = selectedInterface();
+            if (selected) {
+                const applyButton = document.querySelector('[data-action="apply-config"]');
+                const resetButton = document.querySelector('[data-action="reset-config"]');
+                if (applyButton) {
+                    applyButton.disabled = !isDirty(selected.iface);
+                }
+                if (resetButton) {
+                    resetButton.disabled = !isDirty(selected.iface);
+                }
+            }
+        };
+    }
+
+    async function applyConfig() {
+        const selected = selectedInterface();
+        const edited = editedInterface();
+        if (!selected || !edited) {
+            return;
+        }
+        state.loading = true;
+        render();
+        try {
+            const result = await sendToAsync('setInterfaceConfig', {
+                iface: edited.iface,
+                type: edited.type,
+                dhcp: !!edited.dhcp,
+                ip4: edited.configIp4 || '',
+                ip4subnet: edited.configIp4subnet || '',
+                gateway: edited.configGateway || '',
+                dns: normalizeDnsList(edited.configDns),
+            });
+            if (result?.success) {
+                setToast(result.message || t('saved'));
+                window.setTimeout(() => refreshAll(true), 3000);
+            } else {
+                setToast(result?.message || t('saveFailed'), true);
+            }
+        } catch (error) {
+            setToast(`${t('saveFailed')}: ${error.message || error}`, true);
+        } finally {
+            state.loading = false;
+            render();
+        }
+    }
+
+    function resetConfig() {
+        const selected = selectedInterface();
+        if (!selected) {
+            return;
+        }
+        state.edited[selected.iface] = clone(selected);
+        render();
+    }
+
+    async function connectWifi(ssid, password) {
+        const selected = selectedInterface();
+        if (!selected) {
+            return;
+        }
+        state.loading = true;
+        render();
+        try {
+            const result = await sendToAsync('wifiConnect', {
+                ssid,
+                password,
+                iface: selected.iface,
+            });
+            if (result === true) {
+                setToast(`${ssid} ${t('connected')}`);
+            } else {
+                setToast(`${ssid}: ${result}`, true);
+            }
+            await refreshAll(true);
+        } catch (error) {
+            setToast(`${ssid}: ${error.message || error}`, true);
+        } finally {
+            state.loading = false;
+            render();
+        }
+    }
+
+    async function disconnectWifi() {
+        state.loading = true;
+        render();
+        try {
+            const result = await sendToAsync('wifiDisconnect', {
+                ssid: state.wifiConnection || '',
+            });
+            if (result === true) {
+                setToast(t('disconnect'));
+            } else {
+                setToast(`${result}`, true);
+            }
+            await refreshAll(true);
+        } catch (error) {
+            setToast(`${error.message || error}`, true);
+        } finally {
+            state.loading = false;
+            render();
+        }
+    }
+
+    window.initializeWirelessSettingsAdmin = async function initializeWirelessSettingsAdmin() {
+        socket = window.io.connect();
+        socket.on('connect', () => {
+            refreshAll(true).catch(error => setToast(`${t('saveFailed')}: ${error.message || error}`, true));
+        });
+        socket.on('disconnect', () => {
+            state.alive = false;
+            render();
+        });
+        await refreshAll(true);
+    };
+})();

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,9 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const adapter_core_1 = require("@iobroker/adapter-core");
-const node_os_1 = require("node:os");
-const node_dns_1 = require("node:dns");
 const node_child_process_1 = require("node:child_process");
+const node_dns_1 = require("node:dns");
+const node_net_1 = require("node:net");
+const node_os_1 = require("node:os");
 // Take the logic for WI-FI here
 // https://github.com/RPi-Distro/raspi-config/blob/bookworm/raspi-config#L2848
 /**
@@ -38,6 +39,9 @@ class NetworkSettings extends adapter_core_1.Adapter {
                     else if (obj.command === 'wifiDisconnect') {
                         void this.onWifiDisconnect(obj.message).then(result => this.sendTo(obj.from, obj.command, result, obj.callback));
                     }
+                    else if (obj.command === 'setInterfaceConfig') {
+                        void this.onSetInterfaceConfig(obj.message).then(result => this.sendTo(obj.from, obj.command, result, obj.callback));
+                    }
                     else {
                         this.log.error(`Unknown command: ${obj.command}`);
                     }
@@ -45,41 +49,54 @@ class NetworkSettings extends adapter_core_1.Adapter {
             },
         });
     }
-    justExec(command) {
-        if (!this.stopping) {
-            this.cmdRunning = command;
-            return new Promise((resolve, reject) => {
-                try {
-                    (0, node_child_process_1.exec)(command, (error, stdout, stderr) => {
-                        this.cmdRunning = false;
-                        if (error) {
-                            this.log.error(`Cannot execute: ${error.message}`);
-                            reject(error);
-                        }
-                        else if (stderr) {
-                            this.log.error(`Cannot execute: ${stderr}`);
-                            reject(new Error(stderr));
+    static quoteArgForLog(arg) {
+        if (arg === '') {
+            return '""';
+        }
+        return /[\s"]/g.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg;
+    }
+    execFileAsync(command, args = [], options = {}) {
+        if (this.stopping) {
+            return Promise.resolve('');
+        }
+        const logCommand = options.logCommand ||
+            `${options.sudo ? 'sudo ' : ''}${command} ${args.map(NetworkSettings.quoteArgForLog).join(' ')}`.trim();
+        const actualCommand = options.sudo ? 'sudo' : command;
+        const actualArgs = options.sudo ? [command, ...args] : args;
+        this.cmdRunning = logCommand;
+        return new Promise((resolve, reject) => {
+            try {
+                (0, node_child_process_1.execFile)(actualCommand, actualArgs, { maxBuffer: 10 * 1024 * 1024, encoding: 'utf8' }, (error, stdout, stderr) => {
+                    this.cmdRunning = false;
+                    const stdoutText = stdout?.trim() || '';
+                    const stderrText = stderr?.trim() || '';
+                    if (error || stderrText) {
+                        const message = stderrText || error?.message || 'Unknown execution error';
+                        if (options.logErrors !== false) {
+                            this.log.error(`Cannot execute: ${message}`);
                         }
                         else {
-                            this.log.debug(`Result for "${command}": ${stdout}`);
-                            resolve(stdout.trim());
+                            this.log.debug(`Command failed "${logCommand}": ${message}`);
                         }
-                    });
-                }
-                catch (e) {
+                        reject(new Error(message));
+                        return;
+                    }
+                    this.log.debug(`Result for "${logCommand}": ${stdoutText}`);
+                    resolve(stdoutText);
+                });
+            }
+            catch (e) {
+                this.cmdRunning = false;
+                if (options.logErrors !== false) {
                     this.log.error(`Cannot execute.: ${e}`);
-                    reject(new Error(e));
                 }
-            });
-        }
-        return Promise.resolve('');
-    }
-    sudo(command) {
-        return this.justExec(`sudo ${command}`);
+                reject(new Error(e instanceof Error ? e.message : String(e)));
+            }
+        });
     }
     getInterfaces() {
         const ifaces = (0, node_os_1.networkInterfaces)();
-        return Object.keys(ifaces).filter(iface => !ifaces[iface][0].internal);
+        return Object.keys(ifaces).filter(iface => !ifaces[iface]?.[0]?.internal);
     }
     waitForEnd(callback, _started) {
         _started = _started || Date.now();
@@ -104,34 +121,10 @@ class NetworkSettings extends adapter_core_1.Adapter {
         const interfaces = this.getInterfaces();
         if (interfaces.length) {
             await this.setState('info.connection', true, true);
-            // if (process.env.GITHUB_ACTION) {
-            //     this.log.warn('We are running in CI. Cannot check nmcli');
-            //     return;
-            // }
-            // console.log(`ENV: ${JSON.stringify(process.env)}`);
-            // // check that nmcli is installed on a system
-            // try {
-            //     await this.justExec('nmcli device status');
-            //     await this.setState('info.connection', true, true);
-            // } catch (e) {
-            //     this.log.error('This adapter is only for Raspberry Pi (5) or for systems where "nmcli" is installed');
-            //     try {
-            //         const lines = await this.justExec('which nmcli');
-            //         if (!lines) {
-            //             this.log.error(
-            //                 'Cannot find "nmcli": Please be sure that "nmcli" is installed and user "iobroker" may execute it with sudo rights',
-            //             );
-            //         } else {
-            //             this.log.error(`Cannot execute nmcli: ${e}`);
-            //         }
-            //     } catch (e) {
-            //         this.log.error(`Cannot execute "which nmcli": ${e}`);
-            //     }
-            // }
         }
     }
     static parseTable(text) {
-        const lines = text.split('\n');
+        const lines = text.split('\n').filter(line => line.trim());
         let header = lines.shift();
         if (!header) {
             return [];
@@ -164,6 +157,191 @@ class NetworkSettings extends adapter_core_1.Adapter {
         }
         return result;
     }
+    static firstNonEmptyLine(text) {
+        return (text
+            .split('\n')
+            .map(line => line.trim())
+            .find(line => line) || '');
+    }
+    static parseList(text) {
+        return text
+            .split(/[\n,]+/)
+            .map(item => item.trim())
+            .filter(item => item && item !== '--');
+    }
+    static normalizeConnectionName(text) {
+        const connection = NetworkSettings.firstNonEmptyLine(text);
+        return connection === '--' ? '' : connection;
+    }
+    static normalizeConnectionState(state) {
+        const value = state.split(' ')[0].trim().toLowerCase();
+        if (value === 'connected' ||
+            value === 'disconnected' ||
+            value === 'connecting' ||
+            value === 'unavailable' ||
+            value === 'unmanaged') {
+            return value;
+        }
+        return 'unknown';
+    }
+    static parseIpv4Address(text) {
+        const firstAddress = NetworkSettings.parseList(text)[0];
+        if (!firstAddress) {
+            return null;
+        }
+        const parts = firstAddress.split('/');
+        if (parts.length !== 2 || !(0, node_net_1.isIPv4)(parts[0])) {
+            return null;
+        }
+        const prefix = parseInt(parts[1], 10);
+        if (Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
+            return null;
+        }
+        return { address: parts[0], prefix };
+    }
+    static prefixToNetmask(prefix) {
+        if (prefix < 0 || prefix > 32) {
+            return '';
+        }
+        const octets = [];
+        let bits = prefix;
+        for (let i = 0; i < 4; i++) {
+            const usedBits = Math.min(8, Math.max(bits, 0));
+            octets.push(usedBits === 0 ? 0 : 256 - 2 ** (8 - usedBits));
+            bits -= usedBits;
+        }
+        return octets.join('.');
+    }
+    static netmaskToPrefix(netmask) {
+        const octets = netmask
+            .trim()
+            .split('.')
+            .map(value => parseInt(value, 10));
+        if (octets.length !== 4 || octets.some(value => Number.isNaN(value) || value < 0 || value > 255)) {
+            return null;
+        }
+        const binary = octets.map(value => value.toString(2).padStart(8, '0')).join('');
+        if (!/^1*0*$/.test(binary)) {
+            return null;
+        }
+        return binary.replace(/0/g, '').length;
+    }
+    static normalizeIpv4Prefix(subnet) {
+        const value = subnet.trim();
+        if (!value) {
+            return null;
+        }
+        const cleanValue = value.startsWith('/') ? value.substring(1) : value;
+        if (/^\d+$/.test(cleanValue)) {
+            const prefix = parseInt(cleanValue, 10);
+            if (prefix >= 0 && prefix <= 32) {
+                return prefix;
+            }
+            return null;
+        }
+        return NetworkSettings.netmaskToPrefix(cleanValue);
+    }
+    static matchesConnectionType(connectionType, ifaceType) {
+        if (ifaceType === 'ethernet') {
+            return connectionType.includes('ethernet');
+        }
+        if (ifaceType === 'wifi') {
+            return connectionType.includes('wireless') || connectionType.includes('wifi');
+        }
+        return false;
+    }
+    async getNmcliDeviceField(iface, field) {
+        return this.execFileAsync('nmcli', ['-g', field, 'device', 'show', iface], { logErrors: false }).catch(() => '');
+    }
+    async getNmcliConnectionField(connection, field) {
+        return this.execFileAsync('nmcli', ['-g', field, 'connection', 'show', connection], {
+            logErrors: false,
+        }).catch(() => '');
+    }
+    async getDeviceConnectionName(iface) {
+        const connection = await this.getNmcliDeviceField(iface, 'GENERAL.CONNECTION');
+        return NetworkSettings.normalizeConnectionName(connection);
+    }
+    async listConnectionProfiles() {
+        const lines = await this.execFileAsync('nmcli', ['-t', '-e', 'no', '-f', 'NAME,TYPE', 'connection', 'show'], {
+            logErrors: false,
+        }).catch(() => '');
+        return lines
+            .split('\n')
+            .map(line => line.trim())
+            .filter(line => line)
+            .map(line => {
+            const parts = line.split(':');
+            const type = parts.pop() || '';
+            const name = parts.join(':').trim();
+            return { name, type: type.trim() };
+        })
+            .filter(item => item.name && item.type);
+    }
+    async findConnectionForInterface(iface, ifaceType) {
+        const activeConnection = await this.getDeviceConnectionName(iface);
+        if (activeConnection) {
+            return activeConnection;
+        }
+        const connections = await this.listConnectionProfiles();
+        for (const connection of connections) {
+            if (!NetworkSettings.matchesConnectionType(connection.type, ifaceType)) {
+                continue;
+            }
+            const connectionIface = NetworkSettings.firstNonEmptyLine(await this.getNmcliConnectionField(connection.name, 'connection.interface-name'));
+            if (connectionIface === iface) {
+                return connection.name;
+            }
+        }
+        return '';
+    }
+    async ensureEthernetConnection(iface) {
+        const connection = `ioBroker-${iface}`;
+        const existingConnection = NetworkSettings.normalizeConnectionName(await this.getNmcliConnectionField(connection, 'connection.id'));
+        if (existingConnection) {
+            return existingConnection;
+        }
+        await this.execFileAsync('nmcli', ['connection', 'add', 'type', 'ethernet', 'ifname', iface, 'con-name', connection, 'autoconnect', 'yes'], { sudo: true });
+        return connection;
+    }
+    async readConnectionProfile(connection) {
+        const method = NetworkSettings.firstNonEmptyLine(await this.getNmcliConnectionField(connection, 'ipv4.method'));
+        const ip4Address = NetworkSettings.parseIpv4Address(await this.getNmcliConnectionField(connection, 'ipv4.addresses'));
+        const gateway = NetworkSettings.firstNonEmptyLine(await this.getNmcliConnectionField(connection, 'ipv4.gateway'));
+        const dns = NetworkSettings.parseList(await this.getNmcliConnectionField(connection, 'ipv4.dns'));
+        return {
+            dhcp: method === 'auto',
+            ip4: ip4Address?.address || '',
+            ip4subnet: ip4Address ? NetworkSettings.prefixToNetmask(ip4Address.prefix) : '',
+            gateway,
+            dns,
+        };
+    }
+    scheduleConnectionApply(iface, connection) {
+        setTimeout(() => {
+            if (this.stopping) {
+                return;
+            }
+            void (async () => {
+                try {
+                    await this.execFileAsync('nmcli', ['device', 'reapply', iface], {
+                        sudo: true,
+                        logErrors: false,
+                    });
+                    this.log.info(`Applied connection profile "${connection}" on ${iface} via device reapply`);
+                }
+                catch {
+                    try {
+                        await this.execFileAsync('nmcli', ['--wait', '15', 'connection', 'up', 'id', connection, 'ifname', iface], { sudo: true });
+                        this.log.info(`Reconnected interface ${iface} with profile "${connection}"`);
+                    }
+                    catch (e) {
+                        this.log.error(`Cannot reactivate connection "${connection}" on ${iface}: ${e}`);
+                    }
+                }
+            })();
+        }, 250);
+    }
     async onInterfaces() {
         if (this.stopping) {
             return [];
@@ -171,27 +349,33 @@ class NetworkSettings extends adapter_core_1.Adapter {
         const ifaces = (0, node_os_1.networkInterfaces)();
         const result = [];
         Object.keys(ifaces).forEach(iface => {
-            const ip4 = ifaces[iface].find(addr => addr.family === 'IPv4');
-            const ip6 = ifaces[iface].find(addr => addr.family === 'IPv6');
-            const gateway = '';
-            const dns = (0, node_dns_1.getServers)();
-            const dhcp = false;
+            const ifaceEntries = ifaces[iface];
+            if (!ifaceEntries?.length || ifaceEntries[0].internal) {
+                return;
+            }
+            const ip4 = ifaceEntries.find(addr => addr.family === 'IPv4');
+            const ip6 = ifaceEntries.find(addr => addr.family === 'IPv6');
             result.push({
                 iface,
                 ip4: ip4?.address || '',
                 ip4subnet: ip4?.netmask || '',
                 ip6: ip6?.address || '',
                 ip6subnet: ip6?.netmask || '',
-                mac: ifaces[iface][0].mac,
-                gateway,
-                dns,
-                dhcp,
+                mac: ifaceEntries[0].mac,
+                gateway: '',
+                dhcp: true,
+                dns: [],
+                configIp4: '',
+                configIp4subnet: '',
+                configGateway: '',
+                configDns: [],
+                connection: '',
                 type: 'ethernet',
                 status: 'disconnected',
                 editable: false,
             });
         });
-        const lines = await this.justExec('nmcli device status');
+        const lines = await this.execFileAsync('nmcli', ['device', 'status'], { logErrors: false }).catch(() => '');
         const items = NetworkSettings.parseTable(lines);
         // DEVICE         TYPE      STATE                   CONNECTION
         // eth0           ethernet  connected               Wired connection 1
@@ -200,34 +384,61 @@ class NetworkSettings extends adapter_core_1.Adapter {
         // p2p-dev-wlan0  wifi-p2p  disconnected            --
         // Extract status
         for (let i = 0; i < items.length; i++) {
-            const item = result.find(item => item.iface === items[i].DEVICE);
+            if (items[i].TYPE === 'loopback' || items[i].TYPE === 'wifi-p2p') {
+                continue;
+            }
+            const item = result.find(resultItem => resultItem.iface === items[i].DEVICE);
             if (item) {
-                item.status = items[i].STATE.split(' ')[0];
+                item.status = NetworkSettings.normalizeConnectionState(items[i].STATE);
                 item.type = items[i].TYPE;
             }
-            else if (items[i].TYPE !== 'loopback' && items[i].TYPE !== 'wifi-p2p') {
+            else {
                 result.push({
                     iface: items[i].DEVICE,
-                    status: items[i].STATE.split(' ')[0],
+                    status: NetworkSettings.normalizeConnectionState(items[i].STATE),
                     ip4: '',
                     ip4subnet: '',
                     ip6: '',
                     ip6subnet: '',
                     mac: '',
                     gateway: '',
+                    dhcp: true,
                     dns: [],
-                    dhcp: false,
+                    configIp4: '',
+                    configIp4subnet: '',
+                    configGateway: '',
+                    configDns: [],
+                    connection: '',
                     type: items[i].TYPE,
                     editable: false,
                 });
             }
+        }
+        for (const item of result) {
+            item.gateway = NetworkSettings.firstNonEmptyLine(await this.getNmcliDeviceField(item.iface, 'IP4.GATEWAY'));
+            item.dns = NetworkSettings.parseList(await this.getNmcliDeviceField(item.iface, 'IP4.DNS'));
+            if (!item.dns.length && item.status === 'connected') {
+                item.dns = (0, node_dns_1.getServers)();
+            }
+            item.connection = await this.findConnectionForInterface(item.iface, item.type);
+            if (item.connection) {
+                const profile = await this.readConnectionProfile(item.connection);
+                item.dhcp = profile.dhcp;
+                item.configIp4 = profile.ip4;
+                item.configIp4subnet = profile.ip4subnet;
+                item.configGateway = profile.gateway;
+                item.configDns = profile.dns;
+            }
+            item.editable = (item.type === 'ethernet' || item.type === 'wifi') && item.status !== 'unmanaged';
         }
         return result;
     }
     async onWifi() {
         const networks = [];
         if (!this.stopping) {
-            const iwlist = await this.sudo('nmcli dev wifi list --rescan yes');
+            const iwlist = await this.execFileAsync('nmcli', ['dev', 'wifi', 'list', '--rescan', 'yes'], {
+                sudo: true,
+            });
             // IN-USE  BSSID              SSID                MODE   CHAN  RATE        SIGNAL  BARS  SECURITY
             // *       BA:FF:16:XX:F7:94  Android12356        Infra  6     130 Mbit/s  100     ▂▄▆█  WPA2
             //         78:FF:20:XX:5B:83  SSID 1 2         3  Infra  6     130 Mbit/s  92      ▂▄▆█  --
@@ -301,28 +512,16 @@ class NetworkSettings extends adapter_core_1.Adapter {
         if (this.stopping) {
             return '';
         }
-        const lines = await this.justExec('nmcli device status');
-        // DEVICE         TYPE      STATE                   CONNECTION
-        // eth0           ethernet  connected               Wired connection 1
-        // lo             loopback  connected (externally)  lo
-        // wlan0          wifi      connected               Android12345
-        // p2p-dev-wlan0  wifi-p2p  disconnected            --
-        const items = NetworkSettings.parseTable(lines);
-        // Extract status
-        const iface = items.find(item => item.DEVICE === input.iface);
-        if (iface) {
-            return iface.CONNECTION;
-        }
-        return '';
+        return this.getDeviceConnectionName(input.iface);
     }
     async onWifiConnect(input) {
         if (this.stopping) {
             return 'Instance is stopping';
         }
         try {
-            let result = await this.justExec(`nmcli radio wifi`);
+            let result = await this.execFileAsync('nmcli', ['radio', 'wifi']);
             if (result !== 'enabled') {
-                result = await this.sudo(`nmcli radio wifi on`);
+                result = await this.execFileAsync('nmcli', ['radio', 'wifi', 'on'], { sudo: true });
             }
             this.log.debug(`Enable radio => ${result}`);
         }
@@ -330,8 +529,16 @@ class NetworkSettings extends adapter_core_1.Adapter {
             this.log.error(`Cannot enable radio: ${e}`);
         }
         try {
-            const result = await this.sudo(`nmcli device wifi connect "${input.ssid}" password "${input.password}" ifname "${input.iface}"`);
-            this.log.debug(`Set wifi "${input.ssid}" on "${input.iface} => ${result}`);
+            const args = ['device', 'wifi', 'connect', input.ssid];
+            if (input.password) {
+                args.push('password', input.password);
+            }
+            args.push('ifname', input.iface);
+            const result = await this.execFileAsync('nmcli', args, {
+                sudo: true,
+                logCommand: `sudo nmcli device wifi connect ${NetworkSettings.quoteArgForLog(input.ssid)} ${input.password ? 'password *** ' : ''}ifname ${NetworkSettings.quoteArgForLog(input.iface)}`.trim(),
+            });
+            this.log.debug(`Set wifi "${input.ssid}" on "${input.iface}" => ${result}`);
             if (result.includes('successfully')) {
                 return true;
             }
@@ -347,7 +554,7 @@ class NetworkSettings extends adapter_core_1.Adapter {
             return 'Instance is stopping';
         }
         try {
-            const result = await this.sudo(`nmcli connection down id "${input.ssid}"`);
+            const result = await this.execFileAsync('nmcli', ['connection', 'down', 'id', input.ssid], { sudo: true });
             this.log.debug(`Disable wifi "${input.ssid}" => ${result}`);
             if (result.includes('successfully')) {
                 return true;
@@ -357,6 +564,89 @@ class NetworkSettings extends adapter_core_1.Adapter {
         catch (e) {
             this.log.error(`Cannot disconnect from wifi: ${e}`);
             return `Cannot disconnect from wifi: ${e}`;
+        }
+    }
+    async onSetInterfaceConfig(input) {
+        if (this.stopping) {
+            return { success: false, message: 'Instance is stopping' };
+        }
+        if (!input?.iface) {
+            return { success: false, message: 'Interface is required' };
+        }
+        if (input.type !== 'ethernet' && input.type !== 'wifi') {
+            return { success: false, message: 'Only ethernet and WI-FI interfaces are supported' };
+        }
+        try {
+            let connection = await this.findConnectionForInterface(input.iface, input.type);
+            if (!connection && input.type === 'ethernet') {
+                connection = await this.ensureEthernetConnection(input.iface);
+            }
+            if (!connection) {
+                return { success: false, message: 'No editable NetworkManager profile found for this interface' };
+            }
+            const dnsList = Array.isArray(input.dns)
+                ? input.dns.map(item => `${item}`.trim()).filter(Boolean)
+                : NetworkSettings.parseList(input.dns || '');
+            const invalidDns = dnsList.find(dns => !(0, node_net_1.isIPv4)(dns));
+            if (invalidDns) {
+                return { success: false, message: `Invalid DNS server: ${invalidDns}` };
+            }
+            if (input.dhcp) {
+                await this.execFileAsync('nmcli', [
+                    'connection',
+                    'modify',
+                    connection,
+                    'ipv4.method',
+                    'auto',
+                    'ipv4.addresses',
+                    '',
+                    'ipv4.gateway',
+                    '',
+                    'ipv4.dns',
+                    dnsList.join(','),
+                    'ipv4.ignore-auto-dns',
+                    dnsList.length ? 'yes' : 'no',
+                ], { sudo: true });
+            }
+            else {
+                const ip4 = (input.ip4 || '').trim();
+                const prefix = NetworkSettings.normalizeIpv4Prefix(input.ip4subnet || '');
+                const gateway = (input.gateway || '').trim();
+                if (!(0, node_net_1.isIPv4)(ip4)) {
+                    return { success: false, message: 'Invalid IPv4 address' };
+                }
+                if (prefix === null) {
+                    return { success: false, message: 'Invalid subnet mask' };
+                }
+                if (gateway && !(0, node_net_1.isIPv4)(gateway)) {
+                    return { success: false, message: 'Invalid gateway address' };
+                }
+                await this.execFileAsync('nmcli', [
+                    'connection',
+                    'modify',
+                    connection,
+                    'ipv4.method',
+                    'manual',
+                    'ipv4.addresses',
+                    `${ip4}/${prefix}`,
+                    'ipv4.gateway',
+                    gateway,
+                    'ipv4.dns',
+                    dnsList.join(','),
+                    'ipv4.ignore-auto-dns',
+                    'no',
+                ], { sudo: true });
+            }
+            this.scheduleConnectionApply(input.iface, connection);
+            return {
+                success: true,
+                message: 'Network settings saved. The connection will be reapplied shortly.',
+                connection,
+                scheduled: true,
+            };
+        }
+        catch (e) {
+            return { success: false, message: `Cannot save network settings: ${e}` };
         }
     }
 }

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "wireless-settings",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "news": {
       "1.0.2": {
         "en": "Updated for raspberry 5\nChange name to \"wireless-settings\"",
@@ -15,11 +15,24 @@
         "pl": "Aktualizacja dla malin 5\nZmień nazwę na \"wireless- settings\"",
         "uk": "Ажурирано для малини 5\nЗмінити назву на \"безкоштовні налаштування\"",
         "zh-cn": "草莓5更新\n将名称改为“ 无线设置 ”"
+      },
+      "1.1.0": {
+        "en": "Added editable Ethernet and IPv4 network settings (DHCP/static IP, subnet, gateway, DNS)",
+        "de": "Bearbeitbare Ethernet- und IPv4-Netzwerkeinstellungen hinzugefügt (DHCP/statische IP, Subnetz, Gateway, DNS)",
+        "ru": "Добавлены редактируемые настройки Ethernet и IPv4 (DHCP/статический IP, подсеть, шлюз, DNS)",
+        "pt": "Adicionadas configurações editáveis de Ethernet e IPv4 (DHCP/IP estático, sub-rede, gateway, DNS)",
+        "nl": "Bewerkbare Ethernet- en IPv4-instellingen toegevoegd (DHCP/statisch IP, subnet, gateway, DNS)",
+        "fr": "Ajout des paramètres Ethernet et IPv4 modifiables (DHCP/IP statique, sous-réseau, passerelle, DNS)",
+        "it": "Aggiunte impostazioni Ethernet e IPv4 modificabili (DHCP/IP statico, subnet, gateway, DNS)",
+        "es": "Se añadieron ajustes editables de Ethernet e IPv4 (DHCP/IP estática, subred, puerta de enlace, DNS)",
+        "pl": "Dodano edytowalne ustawienia Ethernet i IPv4 (DHCP/statyczny IP, podsieć, brama, DNS)",
+        "uk": "Додано редаговані налаштування Ethernet та IPv4 (DHCP/статична IP, підмережа, шлюз, DNS)",
+        "zh-cn": "新增可编辑的以太网和 IPv4 网络设置（DHCP/静态 IP、子网、网关、DNS）"
       }
     },
     "titleLang": {
-      "en": "Wireless settings",
-      "de": "WLAN-Einstellungen",
+      "en": "Network settings",
+      "de": "Netzwerk-Einstellungen",
       "ru": "Настройки беспроводной связи",
       "pt": "Configurações sem fio",
       "nl": "Draadloze instellingen",
@@ -31,8 +44,8 @@
       "zh-cn": "无线设置"
     },
     "desc": {
-      "en": "Wireless settings for Raspberry Pi",
-      "de": "WLAN-Einstellungen für Raspberry Pi",
+      "en": "Network settings for Raspberry Pi and Linux devices managed by NetworkManager",
+      "de": "Netzwerkeinstellungen für Raspberry Pi und Linux-Geräte mit NetworkManager",
       "ru": "Настройки беспроводной связи для Raspberry Pi",
       "pt": "Configurações sem fio para Raspberry Pi",
       "nl": "Draadloze instellingen voor Raspberry Pi",
@@ -49,7 +62,9 @@
     "keywords": [
       "network",
       "wireless",
-      "wlan",
+      "ethernet",
+      "dhcp",
+      "static ip",
       "raspberry",
       "pi"
     ],

--- a/main.test.js
+++ b/main.test.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai');
+
+describe('wireless-settings package', () => {
+    it('should point to the compiled adapter entry file', () => {
+        const pkg = require('./package.json');
+        expect(pkg.main).to.equal('dist/main.js');
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "iobroker.wireless-settings",
-  "version": "0.6.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.wireless-settings",
-      "version": "0.6.3",
+      "version": "1.1.0",
       "license": "MIT",
+      "os": [
+        "linux"
+      ],
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.wireless-settings",
-  "version": "1.0.2",
-  "description": "This adapter is used to anonymously collect the data on the central server for scientific research",
+  "version": "1.1.0",
+  "description": "Network settings adapter for Raspberry Pi and Linux devices managed by NetworkManager",
   "author": {
     "name": "bluefox",
     "email": "dogafox@gmail.com"
@@ -11,7 +11,10 @@
   "keywords": [
     "ioBroker",
     "network",
-    "data mining"
+    "wireless",
+    "ethernet",
+    "dhcp",
+    "static-ip"
   ],
   "repository": {
     "type": "git",
@@ -65,7 +68,7 @@
     "test": "npm run test:js && npm run test:package",
     "prepublishOnly": "npm run build",
     "lint": "cd src && eslint -c eslint.config.mjs",
-    "build": "tsc -p src/tsconfig.json && node tasks",
+    "build": "tsc -p src/tsconfig.json",
     "tsc": "tsc -p src/tsconfig.json",
     "release": "release-script patch --yes --no-update-lockfile",
     "release-patch": "release-script patch --yes --no-update-lockfile",

--- a/src-admin/src/App.js
+++ b/src-admin/src/App.js
@@ -3,6 +3,7 @@ import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { enqueueSnackbar, SnackbarProvider } from 'notistack';
 
 import {
+    Alert,
     AppBar,
     Tabs,
     Tab,
@@ -123,11 +124,10 @@ class App extends GenericApp {
         super(props, extendedProps);
 
         Object.assign(this.state, {
-            tabValue: window.localStorage.getItem(`wireless.${this.instance}.tab`) || '',
+            tabValue: window.localStorage.getItem(`network.${this.instance}.tab`) || '',
             interfaces: null,
             interfacesChanged: [],
             wifi: [],
-            dns: [],
             wifiConnection: '',
             wifiDialog: false,
             wifiDialogPassword: '',
@@ -140,12 +140,40 @@ class App extends GenericApp {
         });
 
         this.scanWifiTimer = null;
+        this.refreshTimer = null;
+    }
+
+    static normalizeDnsList(dns) {
+        if (!dns) {
+            return [];
+        }
+        if (Array.isArray(dns)) {
+            return dns.map(item => `${item}`.trim()).filter(Boolean);
+        }
+        return dns
+            .split(/[\n,;]+/)
+            .map(item => item.trim())
+            .filter(Boolean);
+    }
+
+    static normalizeInterfaceConfig(interfaceItem) {
+        return {
+            dhcp: !!interfaceItem?.dhcp,
+            configIp4: (interfaceItem?.configIp4 || '').trim(),
+            configIp4subnet: (interfaceItem?.configIp4subnet || '').trim(),
+            configGateway: (interfaceItem?.configGateway || '').trim(),
+            configDns: App.normalizeDnsList(interfaceItem?.configDns),
+        };
     }
 
     componentWillUnmount() {
         if (this.scanWifiTimer) {
             clearTimeout(this.scanWifiTimer);
             this.scanWifiTimer = null;
+        }
+        if (this.refreshTimer) {
+            clearTimeout(this.refreshTimer);
+            this.refreshTimer = null;
         }
         this.socket.unsubscribeState(`system.adapter.wireless-settings.${this.instance}.alive`, this.onAliveChanged);
     }
@@ -168,6 +196,66 @@ class App extends GenericApp {
                 await this.refresh();
             }
         }
+    };
+
+    getEditedInterface() {
+        return this.state.interfacesChanged.find(i => i.iface === this.state.tabValue);
+    }
+
+    updateEditedInterface = update => {
+        this.setState(prevState => {
+            const interfacesChanged = JSON.parse(JSON.stringify(prevState.interfacesChanged));
+            const index = interfacesChanged.findIndex(item => item.iface === prevState.tabValue);
+            if (index === -1) {
+                return null;
+            }
+            interfacesChanged[index] = {
+                ...interfacesChanged[index],
+                ...update,
+            };
+            return { interfacesChanged };
+        });
+    };
+
+    resetInterfaceChanges = iface => {
+        this.setState(prevState => {
+            const interfaces = prevState.interfaces || [];
+            const source = interfaces.find(item => item.iface === iface);
+            if (!source) {
+                return null;
+            }
+            const interfacesChanged = JSON.parse(JSON.stringify(prevState.interfacesChanged));
+            const index = interfacesChanged.findIndex(item => item.iface === iface);
+            if (index === -1) {
+                return null;
+            }
+            interfacesChanged[index] = JSON.parse(JSON.stringify(source));
+            return { interfacesChanged };
+        });
+    };
+
+    isInterfaceDirty = iface => {
+        const original = this.state.interfaces?.find(item => item.iface === iface);
+        const changed = this.state.interfacesChanged?.find(item => item.iface === iface);
+        if (!original || !changed) {
+            return false;
+        }
+        return (
+            JSON.stringify(App.normalizeInterfaceConfig(original)) !== JSON.stringify(App.normalizeInterfaceConfig(changed))
+        );
+    };
+
+    canSaveInterface = interfaceItem => {
+        if (!interfaceItem?.editable || this.state.processing || !this.state.alive) {
+            return false;
+        }
+        if (interfaceItem.type === 'wifi' && !interfaceItem.connection) {
+            return false;
+        }
+        if (interfaceItem.dhcp) {
+            return true;
+        }
+        return !!interfaceItem.configIp4?.trim() && !!interfaceItem.configIp4subnet?.trim();
     };
 
     async refreshCurrentSSID() {
@@ -284,8 +372,7 @@ class App extends GenericApp {
             },
             async () => {
                 await this.refreshWiFi();
-                const dns = await this.socket.sendTo(`wireless-settings.${this.instance}`, 'dns', null);
-                this.setState({ dns, firstRequest: 2 });
+                this.setState({ firstRequest: 2 });
             },
         );
     }
@@ -332,6 +419,81 @@ class App extends GenericApp {
                 }),
         );
     }
+
+    saveInterfaceConfig = interfaceItem => {
+        if (!this.state.alive || !interfaceItem) {
+            return;
+        }
+
+        const payload = {
+            iface: interfaceItem.iface,
+            type: interfaceItem.type,
+            dhcp: !!interfaceItem.dhcp,
+            ip4: interfaceItem.configIp4 || '',
+            ip4subnet: interfaceItem.configIp4subnet || '',
+            gateway: interfaceItem.configGateway || '',
+            dns: App.normalizeDnsList(interfaceItem.configDns),
+        };
+
+        this.setState({ processing: true }, () =>
+            this.socket
+                .sendTo(`wireless-settings.${this.instance}`, 'setInterfaceConfig', payload)
+                .then(result => {
+                    const success = result?.success === true;
+                    const message = I18n.t(result?.message || 'Unable to save network settings');
+
+                    if (success) {
+                        enqueueSnackbar(message, { variant: 'success' });
+                        this.setState(prevState => {
+                            const normalizeDns = item => App.normalizeDnsList(item);
+                            const interfaces = JSON.parse(JSON.stringify(prevState.interfaces || [])).map(item =>
+                                item.iface !== interfaceItem.iface
+                                    ? item
+                                    : {
+                                          ...item,
+                                          dhcp: payload.dhcp,
+                                          connection: result?.connection || item.connection,
+                                          configIp4: payload.ip4,
+                                          configIp4subnet: payload.ip4subnet,
+                                          configGateway: payload.gateway,
+                                          configDns: normalizeDns(payload.dns),
+                                      },
+                            );
+                            const interfacesChanged = JSON.parse(JSON.stringify(prevState.interfacesChanged || [])).map(
+                                item =>
+                                    item.iface !== interfaceItem.iface
+                                        ? item
+                                        : {
+                                              ...item,
+                                              dhcp: payload.dhcp,
+                                              connection: result?.connection || item.connection,
+                                              configIp4: payload.ip4,
+                                              configIp4subnet: payload.ip4subnet,
+                                              configGateway: payload.gateway,
+                                              configDns: normalizeDns(payload.dns),
+                                          },
+                            );
+                            return { interfaces, interfacesChanged, processing: false };
+                        });
+
+                        if (this.refreshTimer) {
+                            clearTimeout(this.refreshTimer);
+                        }
+                        this.refreshTimer = setTimeout(() => {
+                            this.refreshTimer = null;
+                            this.refresh().catch(() => undefined);
+                        }, 3000);
+                    } else {
+                        enqueueSnackbar(message, { variant: 'error' });
+                        this.setState({ processing: false });
+                    }
+                })
+                .catch(error => {
+                    enqueueSnackbar(`${I18n.t('Unable to save network settings')}: ${error}`, { variant: 'error' });
+                    this.setState({ processing: false });
+                }),
+        );
+    };
 
     wifiPasswordApply(apply) {
         const ssid = this.state.wifiDialog;
@@ -423,72 +585,207 @@ class App extends GenericApp {
         }
     }
 
-    renderInterface(interfaceItem) {
+    renderCurrentNetwork(interfaceItem) {
+        return (
+            <div style={{ minWidth: 260, maxWidth: 380 }}>
+                {(interfaceItem.ip4 || interfaceItem.ip6 || interfaceItem.dns?.length || interfaceItem.gateway) && (
+                    <h4 style={{ marginTop: 8 }}>{I18n.t('Current network values')}</h4>
+                )}
+                {interfaceItem.ip4 ? (
+                    <TextField
+                        variant="standard"
+                        style={styles.input}
+                        value={interfaceItem.ip4}
+                        label="IPv4"
+                        disabled
+                        fullWidth
+                    />
+                ) : null}
+                {interfaceItem.ip4 ? (
+                    <TextField
+                        variant="standard"
+                        style={styles.input}
+                        value={interfaceItem.ip4subnet}
+                        label="IPv4 netmask"
+                        disabled
+                        fullWidth
+                    />
+                ) : null}
+                {interfaceItem.gateway ? (
+                    <TextField
+                        variant="standard"
+                        style={styles.input}
+                        value={interfaceItem.gateway}
+                        label={I18n.t('Default gateway')}
+                        disabled
+                        fullWidth
+                    />
+                ) : null}
+                {interfaceItem.ip6 ? <h4>IPv6</h4> : null}
+                {interfaceItem.ip6 ? (
+                    <TextField
+                        variant="standard"
+                        style={styles.input}
+                        value={interfaceItem.ip6}
+                        label="IPv6"
+                        disabled
+                        fullWidth
+                    />
+                ) : null}
+                {interfaceItem.ip6 ? (
+                    <TextField
+                        variant="standard"
+                        value={interfaceItem.ip6subnet}
+                        label="IPv6 netmask"
+                        disabled
+                        fullWidth
+                    />
+                ) : null}
+                {interfaceItem.dns?.length ? <h4>DNS</h4> : null}
+                {interfaceItem.dns?.map((dnsRecord, dnsI) => (
+                    <div key={dnsI}>
+                        <TextField
+                            variant="standard"
+                            value={dnsRecord}
+                            label={I18n.t('DNS record')}
+                            disabled
+                            fullWidth
+                        />
+                    </div>
+                )) || null}
+            </div>
+        );
+    }
+
+    renderIpv4Editor(interfaceItem) {
+        if (!interfaceItem || (interfaceItem.type !== 'ethernet' && interfaceItem.type !== 'wifi')) {
+            return null;
+        }
+
+        const dirty = this.isInterfaceDirty(interfaceItem.iface);
+        const dnsText = App.normalizeDnsList(interfaceItem.configDns).join('\n');
+
+        return (
+            <div style={{ minWidth: 300, maxWidth: 420 }}>
+                <h4 style={{ marginTop: 8 }}>{I18n.t('IPv4 configuration')}</h4>
+                {interfaceItem.connection ? (
+                    <TextField
+                        variant="standard"
+                        style={styles.input}
+                        value={interfaceItem.connection}
+                        label={I18n.t('Connection profile')}
+                        disabled
+                        fullWidth
+                    />
+                ) : null}
+                {!interfaceItem.editable ? (
+                    <Alert severity="info" style={{ marginBottom: 12 }}>
+                        {I18n.t('This interface cannot be edited with NetworkManager')}
+                    </Alert>
+                ) : null}
+                {interfaceItem.type === 'wifi' && !interfaceItem.connection ? (
+                    <Alert severity="info" style={{ marginBottom: 12 }}>
+                        {I18n.t('Connect to a WI-FI network first to edit its IP settings')}
+                    </Alert>
+                ) : null}
+                <FormControlLabel
+                    style={{ marginLeft: 0, marginBottom: 8 }}
+                    control={
+                        <Switch
+                            disabled={this.state.processing || !interfaceItem.editable}
+                            checked={!!interfaceItem.dhcp}
+                            onChange={e =>
+                                this.updateEditedInterface({
+                                    dhcp: e.target.checked,
+                                    ...(e.target.checked
+                                        ? {
+                                              configIp4: '',
+                                              configIp4subnet: '',
+                                              configGateway: '',
+                                          }
+                                        : {}),
+                                })
+                            }
+                        />
+                    }
+                    label={I18n.t('Use DHCP')}
+                />
+                <TextField
+                    variant="standard"
+                    style={styles.input}
+                    value={interfaceItem.configIp4 || ''}
+                    label={I18n.t('Static IPv4 address')}
+                    disabled={this.state.processing || !!interfaceItem.dhcp || !interfaceItem.editable}
+                    fullWidth
+                    onChange={e => this.updateEditedInterface({ configIp4: e.target.value })}
+                />
+                <TextField
+                    variant="standard"
+                    style={styles.input}
+                    value={interfaceItem.configIp4subnet || ''}
+                    label={I18n.t('Subnet mask or prefix')}
+                    disabled={this.state.processing || !!interfaceItem.dhcp || !interfaceItem.editable}
+                    helperText={I18n.t('Examples: 255.255.255.0 or 24')}
+                    fullWidth
+                    onChange={e => this.updateEditedInterface({ configIp4subnet: e.target.value })}
+                />
+                <TextField
+                    variant="standard"
+                    style={styles.input}
+                    value={interfaceItem.configGateway || ''}
+                    label={I18n.t('Default gateway')}
+                    disabled={this.state.processing || !!interfaceItem.dhcp || !interfaceItem.editable}
+                    fullWidth
+                    onChange={e => this.updateEditedInterface({ configGateway: e.target.value })}
+                />
+                <TextField
+                    variant="standard"
+                    style={styles.input}
+                    value={dnsText}
+                    label={I18n.t('DNS servers')}
+                    helperText={I18n.t('One entry per line or separated by commas')}
+                    disabled={this.state.processing || !interfaceItem.editable}
+                    multiline
+                    minRows={2}
+                    fullWidth
+                    onChange={e => this.updateEditedInterface({ configDns: App.normalizeDnsList(e.target.value) })}
+                />
+                <div style={{ display: 'flex', gap: 8, marginTop: 16, flexWrap: 'wrap' }}>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        disabled={!dirty || !this.canSaveInterface(interfaceItem)}
+                        onClick={() => this.saveInterfaceConfig(interfaceItem)}
+                    >
+                        {I18n.t('Apply network settings')}
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        color="grey"
+                        disabled={!dirty || this.state.processing}
+                        onClick={() => this.resetInterfaceChanges(interfaceItem.iface)}
+                    >
+                        {I18n.t('Reset changes')}
+                    </Button>
+                </div>
+                <Alert severity="warning" style={{ marginTop: 16 }}>
+                    {I18n.t(
+                        'Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.',
+                    )}
+                </Alert>
+            </div>
+        );
+    }
+
+    renderInterface(interfaceItem, editedInterface) {
         if (!interfaceItem) {
             return null;
         }
 
         return (
-            <div style={{ display: 'flex', gap: 32 }}>
-                <div style={{ minWidth: 195 }}>
-                    {interfaceItem.ip4 ? <h4 style={{ marginTop: 8 }}>IPv4</h4> : null}
-                    {interfaceItem.ip4 ? (
-                        <TextField
-                            variant="standard"
-                            style={styles.input}
-                            value={interfaceItem.ip4}
-                            label="IPv4"
-                            disabled
-                        />
-                    ) : null}
-                    {interfaceItem.ip4 ? (
-                        <TextField
-                            variant="standard"
-                            style={styles.input}
-                            value={interfaceItem.ip4subnet}
-                            label="IPv4 netmask"
-                            disabled
-                        />
-                    ) : null}
-                    {interfaceItem.gateway ? (
-                        <TextField
-                            variant="standard"
-                            style={styles.input}
-                            value={interfaceItem.gateway}
-                            label={I18n.t('Default gateway')}
-                            disabled
-                        />
-                    ) : null}
-                    {interfaceItem.ip6 ? <h4>IPv6</h4> : null}
-                    {interfaceItem.ip6 ? (
-                        <TextField
-                            variant="standard"
-                            style={styles.input}
-                            value={interfaceItem.ip6}
-                            label="IPv6"
-                            disabled
-                        />
-                    ) : null}
-                    {interfaceItem.ip6 ? (
-                        <TextField
-                            variant="standard"
-                            value={interfaceItem.ip6subnet}
-                            label="IPv6 netmask"
-                            disabled
-                        />
-                    ) : null}
-                    {interfaceItem.dns?.length ? <h4>DNS</h4> : null}
-                    {interfaceItem.dns?.map((dnsRecord, dnsI) => (
-                        <div key={dnsI}>
-                            <TextField
-                                variant="standard"
-                                value={dnsRecord}
-                                label={I18n.t('DNS record')}
-                                disabled
-                            />
-                        </div>
-                    )) || null}
-                </div>
+            <div style={{ display: 'flex', gap: 32, flexWrap: 'wrap' }}>
+                {this.renderCurrentNetwork(interfaceItem)}
+                {this.renderIpv4Editor(editedInterface || interfaceItem)}
                 {this.renderWireless(interfaceItem)}
             </div>
         );
@@ -500,7 +797,7 @@ class App extends GenericApp {
         }
 
         return (
-            <div>
+            <div style={{ minWidth: 260 }}>
                 {this.state.processing || this.state.firstRequest < 2 ? (
                     <LinearProgress />
                 ) : (
@@ -599,6 +896,7 @@ class App extends GenericApp {
         }
 
         const interIndex = this.state.interfaces.findIndex(i => i.iface === this.state.tabValue);
+        const editedIndex = this.state.interfacesChanged.findIndex(i => i.iface === this.state.tabValue);
 
         return (
             <StyledEngineProvider injectFirst>
@@ -656,7 +954,11 @@ class App extends GenericApp {
 
                         <div style={styles.tabContent}>
                             {!this.state.interfaces?.length && !this.state.alive ? I18n.t('Instance is not running') : null}
-                            {interIndex !== -1 && this.renderInterface(this.state.interfaces[interIndex], interIndex)}
+                            {interIndex !== -1 &&
+                                this.renderInterface(
+                                    this.state.interfaces[interIndex],
+                                    editedIndex !== -1 ? this.state.interfacesChanged[editedIndex] : undefined,
+                                )}
                         </div>
                         {this.renderWifiDialog()}
                     </div>

--- a/src-admin/src/i18n/de.json
+++ b/src-admin/src/i18n/de.json
@@ -31,5 +31,21 @@
   "not connected": "nicht verbunden",
   "Apply": "Anwenden",
   "WI-FI password": "WLAN-Passwort",
-  "Instance is not running": "Instanz läuft nicht"
+  "Instance is not running": "Instanz läuft nicht",
+  "Current network values": "Aktuelle Netzwerkwerte",
+  "IPv4 configuration": "IPv4-Konfiguration",
+  "Connection profile": "Verbindungsprofil",
+  "Use DHCP": "DHCP verwenden",
+  "Static IPv4 address": "Statische IPv4-Adresse",
+  "Subnet mask or prefix": "Subnetzmaske oder Präfix",
+  "Examples: 255.255.255.0 or 24": "Beispiele: 255.255.255.0 oder 24",
+  "DNS servers": "DNS-Server",
+  "One entry per line or separated by commas": "Ein Eintrag pro Zeile oder durch Kommas getrennt",
+  "Apply network settings": "Netzwerkeinstellungen anwenden",
+  "Reset changes": "Änderungen zurücksetzen",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Das Anwenden der Netzwerkeinstellungen kann die aktuelle Verbindung unterbrechen. Wenn sich die IP-Adresse ändert, öffne die Admin-Seite mit der neuen Adresse erneut.",
+  "Network settings saved. The connection will be reapplied shortly.": "Netzwerkeinstellungen gespeichert. Die Verbindung wird in Kürze neu angewendet.",
+  "Unable to save network settings": "Netzwerkeinstellungen konnten nicht gespeichert werden",
+  "This interface cannot be edited with NetworkManager": "Diese Schnittstelle kann nicht über NetworkManager bearbeitet werden",
+  "Connect to a WI-FI network first to edit its IP settings": "Verbinde dich zuerst mit einem WLAN, um dessen IP-Einstellungen zu bearbeiten"
 }

--- a/src-admin/src/i18n/en.json
+++ b/src-admin/src/i18n/en.json
@@ -31,5 +31,21 @@
   "De-bounces": "De-bounces",
   "debounce": "de-bounce",
   "ms": "ms",
-  "Instance is not running": "Instance is not running"
+  "Instance is not running": "Instance is not running",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/es.json
+++ b/src-admin/src/i18n/es.json
@@ -31,5 +31,21 @@
   "not connected": "No conectado",
   "Apply": "Aplicar",
   "WI-FI password": "Contraseña de WI-FI",
-  "Instance is not running": "La instancia no se está ejecutando"
+  "Instance is not running": "La instancia no se está ejecutando",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/fr.json
+++ b/src-admin/src/i18n/fr.json
@@ -31,5 +31,21 @@
   "not connected": "non connecté",
   "Apply": "Appliquer",
   "WI-FI password": "Mot de passe Wi-Fi",
-  "Instance is not running": "L'instance n'est pas en cours d'exécution"
+  "Instance is not running": "L'instance n'est pas en cours d'exécution",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/it.json
+++ b/src-admin/src/i18n/it.json
@@ -31,5 +31,21 @@
   "not connected": "non connesso",
   "Apply": "Fare domanda a",
   "WI-FI password": "password WI-FI",
-  "Instance is not running": "L'istanza non è in esecuzione"
+  "Instance is not running": "L'istanza non è in esecuzione",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/nl.json
+++ b/src-admin/src/i18n/nl.json
@@ -31,5 +31,21 @@
   "not connected": "niet verbonden",
   "Apply": "Toepassen",
   "WI-FI password": "WI-FI-wachtwoord",
-  "Instance is not running": "Instantie wordt niet uitgevoerd"
+  "Instance is not running": "Instantie wordt niet uitgevoerd",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/pl.json
+++ b/src-admin/src/i18n/pl.json
@@ -31,5 +31,21 @@
   "not connected": "nie połączony",
   "Apply": "Stosować",
   "WI-FI password": "Hasło Wi-Fi",
-  "Instance is not running": "Instancja nie jest uruchomiona"
+  "Instance is not running": "Instancja nie jest uruchomiona",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/pt.json
+++ b/src-admin/src/i18n/pt.json
@@ -31,5 +31,21 @@
   "not connected": "não conectado",
   "Apply": "Aplicar",
   "WI-FI password": "Senha do WI-FI",
-  "Instance is not running": "A instância não está em execução"
+  "Instance is not running": "A instância não está em execução",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/ru.json
+++ b/src-admin/src/i18n/ru.json
@@ -31,5 +31,21 @@
   "not connected": "не подключен",
   "Apply": "Применять",
   "WI-FI password": "Пароль WI-FI",
-  "Instance is not running": "Экземпляр не запущен"
+  "Instance is not running": "Экземпляр не запущен",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/uk.json
+++ b/src-admin/src/i18n/uk.json
@@ -31,5 +31,21 @@
   "seconds": "секунд",
   "Apply": "Застосувати",
   "WI-FI password": "Пароль WI-FI",
-  "Instance is not running": "Екземпляр не запущено"
+  "Instance is not running": "Екземпляр не запущено",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src-admin/src/i18n/zh-cn.json
+++ b/src-admin/src/i18n/zh-cn.json
@@ -31,5 +31,21 @@
   "not connected": "未连接",
   "Apply": "申请",
   "WI-FI password": "WI-FI密码",
-  "Instance is not running": "实例未运行"
+  "Instance is not running": "实例未运行",
+  "Current network values": "Current network values",
+  "IPv4 configuration": "IPv4 configuration",
+  "Connection profile": "Connection profile",
+  "Use DHCP": "Use DHCP",
+  "Static IPv4 address": "Static IPv4 address",
+  "Subnet mask or prefix": "Subnet mask or prefix",
+  "Examples: 255.255.255.0 or 24": "Examples: 255.255.255.0 or 24",
+  "DNS servers": "DNS servers",
+  "One entry per line or separated by commas": "One entry per line or separated by commas",
+  "Apply network settings": "Apply network settings",
+  "Reset changes": "Reset changes",
+  "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.": "Applying network changes may interrupt the current connection. If the IP address changes, reopen the admin page using the new address.",
+  "Network settings saved. The connection will be reapplied shortly.": "Network settings saved. The connection will be reapplied shortly.",
+  "Unable to save network settings": "Unable to save network settings",
+  "This interface cannot be edited with NetworkManager": "This interface cannot be edited with NetworkManager",
+  "Connect to a WI-FI network first to edit its IP settings": "Connect to a WI-FI network first to edit its IP settings"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import { Adapter, type AdapterOptions } from '@iobroker/adapter-core';
-import { networkInterfaces } from 'node:os';
+import { execFile } from 'node:child_process';
 import { getServers as getDnsServers } from 'node:dns';
-import { exec } from 'node:child_process';
+import { isIPv4 } from 'node:net';
+import { networkInterfaces } from 'node:os';
 
-type ConnectionState = 'connected' | 'disconnected' | 'connecting';
+type ConnectionState = 'connected' | 'disconnected' | 'connecting' | 'unavailable' | 'unmanaged' | 'unknown';
+
 interface WirelessNetwork {
     security: '--' | 'WPA' | 'WPA2';
     ssid: string;
@@ -22,9 +24,51 @@ interface NetworkInterface {
     gateway: string;
     dhcp: boolean;
     dns: string[];
+    configIp4: string;
+    configIp4subnet: string;
+    configGateway: string;
+    configDns: string[];
+    connection: string;
     type: 'ethernet' | 'loopback' | 'wifi' | 'wifi-p2p';
-    editable: false;
+    editable: boolean;
+    virtual?: boolean;
     status: ConnectionState;
+}
+
+interface SetInterfaceConfigInput {
+    iface: string;
+    type: 'ethernet' | 'wifi';
+    dhcp: boolean;
+    ip4?: string;
+    ip4subnet?: string;
+    gateway?: string;
+    dns?: string[] | string;
+}
+
+interface SetInterfaceConfigResult {
+    success: boolean;
+    message: string;
+    connection?: string;
+    scheduled?: boolean;
+}
+
+interface ConnectionProfile {
+    dhcp: boolean;
+    ip4: string;
+    ip4subnet: string;
+    gateway: string;
+    dns: string[];
+}
+
+interface ExecuteOptions {
+    sudo?: boolean;
+    logCommand?: string;
+    logErrors?: boolean;
+}
+
+interface ConnectionInfo {
+    name: string;
+    type: string;
 }
 
 // Take the logic for WI-FI here
@@ -64,6 +108,10 @@ class NetworkSettings extends Adapter {
                         void this.onWifiDisconnect(obj.message).then(result =>
                             this.sendTo(obj.from, obj.command, result, obj.callback),
                         );
+                    } else if (obj.command === 'setInterfaceConfig') {
+                        void this.onSetInterfaceConfig(obj.message).then(result =>
+                            this.sendTo(obj.from, obj.command, result, obj.callback),
+                        );
                     } else {
                         this.log.error(`Unknown command: ${obj.command}`);
                     }
@@ -72,40 +120,65 @@ class NetworkSettings extends Adapter {
         });
     }
 
-    justExec(command: string): Promise<string> {
-        if (!this.stopping) {
-            this.cmdRunning = command;
-            return new Promise((resolve, reject) => {
-                try {
-                    exec(command, (error, stdout, stderr) => {
-                        this.cmdRunning = false;
-                        if (error) {
-                            this.log.error(`Cannot execute: ${error.message}`);
-                            reject(error);
-                        } else if (stderr) {
-                            this.log.error(`Cannot execute: ${stderr}`);
-                            reject(new Error(stderr));
-                        } else {
-                            this.log.debug(`Result for "${command}": ${stdout}`);
-                            resolve(stdout.trim());
-                        }
-                    });
-                } catch (e) {
-                    this.log.error(`Cannot execute.: ${e}`);
-                    reject(new Error(e));
-                }
-            });
+    private static quoteArgForLog(arg: string): string {
+        if (arg === '') {
+            return '""';
         }
-        return Promise.resolve('');
+        return /[\s"]/g.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg;
     }
 
-    sudo(command: string): Promise<string> {
-        return this.justExec(`sudo ${command}`);
+    private execFileAsync(command: string, args: string[] = [], options: ExecuteOptions = {}): Promise<string> {
+        if (this.stopping) {
+            return Promise.resolve('');
+        }
+
+        const logCommand =
+            options.logCommand ||
+            `${options.sudo ? 'sudo ' : ''}${command} ${args.map(NetworkSettings.quoteArgForLog).join(' ')}`.trim();
+        const actualCommand = options.sudo ? 'sudo' : command;
+        const actualArgs = options.sudo ? [command, ...args] : args;
+
+        this.cmdRunning = logCommand;
+
+        return new Promise((resolve, reject) => {
+            try {
+                execFile(
+                    actualCommand,
+                    actualArgs,
+                    { maxBuffer: 10 * 1024 * 1024, encoding: 'utf8' },
+                    (error, stdout, stderr) => {
+                        this.cmdRunning = false;
+                        const stdoutText = stdout?.trim() || '';
+                        const stderrText = stderr?.trim() || '';
+
+                        if (error || stderrText) {
+                            const message = stderrText || error?.message || 'Unknown execution error';
+                            if (options.logErrors !== false) {
+                                this.log.error(`Cannot execute: ${message}`);
+                            } else {
+                                this.log.debug(`Command failed "${logCommand}": ${message}`);
+                            }
+                            reject(new Error(message));
+                            return;
+                        }
+
+                        this.log.debug(`Result for "${logCommand}": ${stdoutText}`);
+                        resolve(stdoutText);
+                    },
+                );
+            } catch (e) {
+                this.cmdRunning = false;
+                if (options.logErrors !== false) {
+                    this.log.error(`Cannot execute.: ${e}`);
+                }
+                reject(new Error(e instanceof Error ? e.message : String(e)));
+            }
+        });
     }
 
     getInterfaces(): string[] {
         const ifaces = networkInterfaces();
-        return Object.keys(ifaces).filter(iface => !ifaces[iface][0].internal);
+        return Object.keys(ifaces).filter(iface => !ifaces[iface]?.[0]?.internal);
     }
 
     waitForEnd(callback?: (timeout: boolean) => void, _started?: number): void {
@@ -132,35 +205,11 @@ class NetworkSettings extends Adapter {
         const interfaces: string[] = this.getInterfaces();
         if (interfaces.length) {
             await this.setState('info.connection', true, true);
-            // if (process.env.GITHUB_ACTION) {
-            //     this.log.warn('We are running in CI. Cannot check nmcli');
-            //     return;
-            // }
-            // console.log(`ENV: ${JSON.stringify(process.env)}`);
-            // // check that nmcli is installed on a system
-            // try {
-            //     await this.justExec('nmcli device status');
-            //     await this.setState('info.connection', true, true);
-            // } catch (e) {
-            //     this.log.error('This adapter is only for Raspberry Pi (5) or for systems where "nmcli" is installed');
-            //     try {
-            //         const lines = await this.justExec('which nmcli');
-            //         if (!lines) {
-            //             this.log.error(
-            //                 'Cannot find "nmcli": Please be sure that "nmcli" is installed and user "iobroker" may execute it with sudo rights',
-            //             );
-            //         } else {
-            //             this.log.error(`Cannot execute nmcli: ${e}`);
-            //         }
-            //     } catch (e) {
-            //         this.log.error(`Cannot execute "which nmcli": ${e}`);
-            //     }
-            // }
         }
     }
 
     static parseTable(text: string): Record<string, string>[] {
-        const lines = text.split('\n');
+        const lines = text.split('\n').filter(line => line.trim());
         let header = lines.shift();
         if (!header) {
             return [];
@@ -196,34 +245,274 @@ class NetworkSettings extends Adapter {
         return result;
     }
 
+    private static firstNonEmptyLine(text: string): string {
+        return (
+            text
+                .split('\n')
+                .map(line => line.trim())
+                .find(line => line) || ''
+        );
+    }
+
+    private static parseList(text: string): string[] {
+        return text
+            .split(/[\n,]+/)
+            .map(item => item.trim())
+            .filter(item => item && item !== '--');
+    }
+
+    private static normalizeConnectionName(text: string): string {
+        const connection = NetworkSettings.firstNonEmptyLine(text);
+        return connection === '--' ? '' : connection;
+    }
+
+    private static normalizeConnectionState(state: string): ConnectionState {
+        const value = state.split(' ')[0].trim().toLowerCase();
+        if (
+            value === 'connected' ||
+            value === 'disconnected' ||
+            value === 'connecting' ||
+            value === 'unavailable' ||
+            value === 'unmanaged'
+        ) {
+            return value;
+        }
+        return 'unknown';
+    }
+
+    private static parseIpv4Address(text: string): { address: string; prefix: number } | null {
+        const firstAddress = NetworkSettings.parseList(text)[0];
+        if (!firstAddress) {
+            return null;
+        }
+
+        const parts = firstAddress.split('/');
+        if (parts.length !== 2 || !isIPv4(parts[0])) {
+            return null;
+        }
+
+        const prefix = parseInt(parts[1], 10);
+        if (Number.isNaN(prefix) || prefix < 0 || prefix > 32) {
+            return null;
+        }
+
+        return { address: parts[0], prefix };
+    }
+
+    private static prefixToNetmask(prefix: number): string {
+        if (prefix < 0 || prefix > 32) {
+            return '';
+        }
+        const octets: number[] = [];
+        let bits = prefix;
+        for (let i = 0; i < 4; i++) {
+            const usedBits = Math.min(8, Math.max(bits, 0));
+            octets.push(usedBits === 0 ? 0 : 256 - 2 ** (8 - usedBits));
+            bits -= usedBits;
+        }
+        return octets.join('.');
+    }
+
+    private static netmaskToPrefix(netmask: string): number | null {
+        const octets = netmask
+            .trim()
+            .split('.')
+            .map(value => parseInt(value, 10));
+
+        if (octets.length !== 4 || octets.some(value => Number.isNaN(value) || value < 0 || value > 255)) {
+            return null;
+        }
+
+        const binary = octets.map(value => value.toString(2).padStart(8, '0')).join('');
+        if (!/^1*0*$/.test(binary)) {
+            return null;
+        }
+
+        return binary.replace(/0/g, '').length;
+    }
+
+    private static normalizeIpv4Prefix(subnet: string): number | null {
+        const value = subnet.trim();
+        if (!value) {
+            return null;
+        }
+
+        const cleanValue = value.startsWith('/') ? value.substring(1) : value;
+        if (/^\d+$/.test(cleanValue)) {
+            const prefix = parseInt(cleanValue, 10);
+            if (prefix >= 0 && prefix <= 32) {
+                return prefix;
+            }
+            return null;
+        }
+
+        return NetworkSettings.netmaskToPrefix(cleanValue);
+    }
+
+    private static matchesConnectionType(connectionType: string, ifaceType: NetworkInterface['type']): boolean {
+        if (ifaceType === 'ethernet') {
+            return connectionType.includes('ethernet');
+        }
+        if (ifaceType === 'wifi') {
+            return connectionType.includes('wireless') || connectionType.includes('wifi');
+        }
+        return false;
+    }
+
+    private async getNmcliDeviceField(iface: string, field: string): Promise<string> {
+        return this.execFileAsync('nmcli', ['-g', field, 'device', 'show', iface], { logErrors: false }).catch(() => '');
+    }
+
+    private async getNmcliConnectionField(connection: string, field: string): Promise<string> {
+        return this.execFileAsync('nmcli', ['-g', field, 'connection', 'show', connection], {
+            logErrors: false,
+        }).catch(() => '');
+    }
+
+    private async getDeviceConnectionName(iface: string): Promise<string> {
+        const connection = await this.getNmcliDeviceField(iface, 'GENERAL.CONNECTION');
+        return NetworkSettings.normalizeConnectionName(connection);
+    }
+
+    private async listConnectionProfiles(): Promise<ConnectionInfo[]> {
+        const lines = await this.execFileAsync('nmcli', ['-t', '-e', 'no', '-f', 'NAME,TYPE', 'connection', 'show'], {
+            logErrors: false,
+        }).catch(() => '');
+
+        return lines
+            .split('\n')
+            .map(line => line.trim())
+            .filter(line => line)
+            .map(line => {
+                const parts = line.split(':');
+                const type = parts.pop() || '';
+                const name = parts.join(':').trim();
+                return { name, type: type.trim() };
+            })
+            .filter(item => item.name && item.type);
+    }
+
+    private async findConnectionForInterface(iface: string, ifaceType: NetworkInterface['type']): Promise<string> {
+        const activeConnection = await this.getDeviceConnectionName(iface);
+        if (activeConnection) {
+            return activeConnection;
+        }
+
+        const connections = await this.listConnectionProfiles();
+        for (const connection of connections) {
+            if (!NetworkSettings.matchesConnectionType(connection.type, ifaceType)) {
+                continue;
+            }
+            const connectionIface = NetworkSettings.firstNonEmptyLine(
+                await this.getNmcliConnectionField(connection.name, 'connection.interface-name'),
+            );
+            if (connectionIface === iface) {
+                return connection.name;
+            }
+        }
+
+        return '';
+    }
+
+    private async ensureEthernetConnection(iface: string): Promise<string> {
+        const connection = `ioBroker-${iface}`;
+        const existingConnection = NetworkSettings.normalizeConnectionName(
+            await this.getNmcliConnectionField(connection, 'connection.id'),
+        );
+        if (existingConnection) {
+            return existingConnection;
+        }
+
+        await this.execFileAsync(
+            'nmcli',
+            ['connection', 'add', 'type', 'ethernet', 'ifname', iface, 'con-name', connection, 'autoconnect', 'yes'],
+            { sudo: true },
+        );
+        return connection;
+    }
+
+    private async readConnectionProfile(connection: string): Promise<ConnectionProfile> {
+        const method = NetworkSettings.firstNonEmptyLine(await this.getNmcliConnectionField(connection, 'ipv4.method'));
+        const ip4Address = NetworkSettings.parseIpv4Address(await this.getNmcliConnectionField(connection, 'ipv4.addresses'));
+        const gateway = NetworkSettings.firstNonEmptyLine(await this.getNmcliConnectionField(connection, 'ipv4.gateway'));
+        const dns = NetworkSettings.parseList(await this.getNmcliConnectionField(connection, 'ipv4.dns'));
+
+        return {
+            dhcp: method === 'auto',
+            ip4: ip4Address?.address || '',
+            ip4subnet: ip4Address ? NetworkSettings.prefixToNetmask(ip4Address.prefix) : '',
+            gateway,
+            dns,
+        };
+    }
+
+    private scheduleConnectionApply(iface: string, connection: string): void {
+        setTimeout(() => {
+            if (this.stopping) {
+                return;
+            }
+
+            void (async () => {
+                try {
+                    await this.execFileAsync('nmcli', ['device', 'reapply', iface], {
+                        sudo: true,
+                        logErrors: false,
+                    });
+                    this.log.info(`Applied connection profile "${connection}" on ${iface} via device reapply`);
+                } catch {
+                    try {
+                        await this.execFileAsync(
+                            'nmcli',
+                            ['--wait', '15', 'connection', 'up', 'id', connection, 'ifname', iface],
+                            { sudo: true },
+                        );
+                        this.log.info(`Reconnected interface ${iface} with profile "${connection}"`);
+                    } catch (e) {
+                        this.log.error(`Cannot reactivate connection "${connection}" on ${iface}: ${e}`);
+                    }
+                }
+            })();
+        }, 250);
+    }
+
     async onInterfaces(): Promise<NetworkInterface[]> {
         if (this.stopping) {
             return [];
         }
+
         const ifaces = networkInterfaces();
         const result: NetworkInterface[] = [];
+
         Object.keys(ifaces).forEach(iface => {
-            const ip4 = ifaces[iface].find(addr => addr.family === 'IPv4');
-            const ip6 = ifaces[iface].find(addr => addr.family === 'IPv6');
-            const gateway = '';
-            const dns = getDnsServers();
-            const dhcp = false;
+            const ifaceEntries = ifaces[iface];
+            if (!ifaceEntries?.length || ifaceEntries[0].internal) {
+                return;
+            }
+
+            const ip4 = ifaceEntries.find(addr => addr.family === 'IPv4');
+            const ip6 = ifaceEntries.find(addr => addr.family === 'IPv6');
             result.push({
                 iface,
                 ip4: ip4?.address || '',
                 ip4subnet: ip4?.netmask || '',
                 ip6: ip6?.address || '',
                 ip6subnet: ip6?.netmask || '',
-                mac: ifaces[iface][0].mac,
-                gateway,
-                dns,
-                dhcp,
+                mac: ifaceEntries[0].mac,
+                gateway: '',
+                dhcp: true,
+                dns: [],
+                configIp4: '',
+                configIp4subnet: '',
+                configGateway: '',
+                configDns: [],
+                connection: '',
                 type: 'ethernet',
                 status: 'disconnected',
                 editable: false,
             });
         });
-        const lines = await this.justExec('nmcli device status');
+
+        const lines = await this.execFileAsync('nmcli', ['device', 'status'], { logErrors: false }).catch(() => '');
         const items = NetworkSettings.parseTable(lines);
         // DEVICE         TYPE      STATE                   CONNECTION
         // eth0           ethernet  connected               Wired connection 1
@@ -233,26 +522,54 @@ class NetworkSettings extends Adapter {
 
         // Extract status
         for (let i = 0; i < items.length; i++) {
-            const item = result.find(item => item.iface === items[i].DEVICE);
+            if (items[i].TYPE === 'loopback' || items[i].TYPE === 'wifi-p2p') {
+                continue;
+            }
+            const item = result.find(resultItem => resultItem.iface === items[i].DEVICE);
             if (item) {
-                item.status = items[i].STATE.split(' ')[0] as ConnectionState;
+                item.status = NetworkSettings.normalizeConnectionState(items[i].STATE);
                 item.type = items[i].TYPE as 'ethernet' | 'loopback' | 'wifi' | 'wifi-p2p';
-            } else if (items[i].TYPE !== 'loopback' && items[i].TYPE !== 'wifi-p2p') {
+            } else {
                 result.push({
                     iface: items[i].DEVICE,
-                    status: items[i].STATE.split(' ')[0] as ConnectionState,
+                    status: NetworkSettings.normalizeConnectionState(items[i].STATE),
                     ip4: '',
                     ip4subnet: '',
                     ip6: '',
                     ip6subnet: '',
                     mac: '',
                     gateway: '',
+                    dhcp: true,
                     dns: [],
-                    dhcp: false,
+                    configIp4: '',
+                    configIp4subnet: '',
+                    configGateway: '',
+                    configDns: [],
+                    connection: '',
                     type: items[i].TYPE as 'ethernet' | 'loopback' | 'wifi' | 'wifi-p2p',
                     editable: false,
                 });
             }
+        }
+
+        for (const item of result) {
+            item.gateway = NetworkSettings.firstNonEmptyLine(await this.getNmcliDeviceField(item.iface, 'IP4.GATEWAY'));
+            item.dns = NetworkSettings.parseList(await this.getNmcliDeviceField(item.iface, 'IP4.DNS'));
+            if (!item.dns.length && item.status === 'connected') {
+                item.dns = getDnsServers();
+            }
+
+            item.connection = await this.findConnectionForInterface(item.iface, item.type);
+            if (item.connection) {
+                const profile = await this.readConnectionProfile(item.connection);
+                item.dhcp = profile.dhcp;
+                item.configIp4 = profile.ip4;
+                item.configIp4subnet = profile.ip4subnet;
+                item.configGateway = profile.gateway;
+                item.configDns = profile.dns;
+            }
+
+            item.editable = (item.type === 'ethernet' || item.type === 'wifi') && item.status !== 'unmanaged';
         }
 
         return result;
@@ -262,7 +579,9 @@ class NetworkSettings extends Adapter {
         const networks: WirelessNetwork[] = [];
 
         if (!this.stopping) {
-            const iwlist = await this.sudo('nmcli dev wifi list --rescan yes');
+            const iwlist = await this.execFileAsync('nmcli', ['dev', 'wifi', 'list', '--rescan', 'yes'], {
+                sudo: true,
+            });
             // IN-USE  BSSID              SSID                MODE   CHAN  RATE        SIGNAL  BARS  SECURITY
             // *       BA:FF:16:XX:F7:94  Android12356        Infra  6     130 Mbit/s  100     ▂▄▆█  WPA2
             //         78:FF:20:XX:5B:83  SSID 1 2         3  Infra  6     130 Mbit/s  92      ▂▄▆█  --
@@ -340,20 +659,7 @@ class NetworkSettings extends Adapter {
         if (this.stopping) {
             return '';
         }
-        const lines = await this.justExec('nmcli device status');
-        // DEVICE         TYPE      STATE                   CONNECTION
-        // eth0           ethernet  connected               Wired connection 1
-        // lo             loopback  connected (externally)  lo
-        // wlan0          wifi      connected               Android12345
-        // p2p-dev-wlan0  wifi-p2p  disconnected            --
-        const items: Record<string, string>[] = NetworkSettings.parseTable(lines);
-
-        // Extract status
-        const iface = items.find(item => item.DEVICE === input.iface);
-        if (iface) {
-            return iface.CONNECTION;
-        }
-        return '';
+        return this.getDeviceConnectionName(input.iface);
     }
 
     async onWifiConnect(input: { ssid: string; password: string; iface: string }): Promise<true | string> {
@@ -361,9 +667,9 @@ class NetworkSettings extends Adapter {
             return 'Instance is stopping';
         }
         try {
-            let result = await this.justExec(`nmcli radio wifi`);
+            let result = await this.execFileAsync('nmcli', ['radio', 'wifi']);
             if (result !== 'enabled') {
-                result = await this.sudo(`nmcli radio wifi on`);
+                result = await this.execFileAsync('nmcli', ['radio', 'wifi', 'on'], { sudo: true });
             }
             this.log.debug(`Enable radio => ${result}`);
         } catch (e) {
@@ -371,10 +677,18 @@ class NetworkSettings extends Adapter {
         }
 
         try {
-            const result = await this.sudo(
-                `nmcli device wifi connect "${input.ssid}" password "${input.password}" ifname "${input.iface}"`,
-            );
-            this.log.debug(`Set wifi "${input.ssid}" on "${input.iface} => ${result}`);
+            const args = ['device', 'wifi', 'connect', input.ssid];
+            if (input.password) {
+                args.push('password', input.password);
+            }
+            args.push('ifname', input.iface);
+            const result = await this.execFileAsync('nmcli', args, {
+                sudo: true,
+                logCommand: `sudo nmcli device wifi connect ${NetworkSettings.quoteArgForLog(input.ssid)} ${
+                    input.password ? 'password *** ' : ''
+                }ifname ${NetworkSettings.quoteArgForLog(input.iface)}`.trim(),
+            });
+            this.log.debug(`Set wifi "${input.ssid}" on "${input.iface}" => ${result}`);
             if (result.includes('successfully')) {
                 return true;
             }
@@ -390,7 +704,7 @@ class NetworkSettings extends Adapter {
             return 'Instance is stopping';
         }
         try {
-            const result = await this.sudo(`nmcli connection down id "${input.ssid}"`);
+            const result = await this.execFileAsync('nmcli', ['connection', 'down', 'id', input.ssid], { sudo: true });
             this.log.debug(`Disable wifi "${input.ssid}" => ${result}`);
             if (result.includes('successfully')) {
                 return true;
@@ -399,6 +713,102 @@ class NetworkSettings extends Adapter {
         } catch (e) {
             this.log.error(`Cannot disconnect from wifi: ${e}`);
             return `Cannot disconnect from wifi: ${e}`;
+        }
+    }
+
+    async onSetInterfaceConfig(input: SetInterfaceConfigInput): Promise<SetInterfaceConfigResult> {
+        if (this.stopping) {
+            return { success: false, message: 'Instance is stopping' };
+        }
+        if (!input?.iface) {
+            return { success: false, message: 'Interface is required' };
+        }
+        if (input.type !== 'ethernet' && input.type !== 'wifi') {
+            return { success: false, message: 'Only ethernet and WI-FI interfaces are supported' };
+        }
+
+        try {
+            let connection = await this.findConnectionForInterface(input.iface, input.type);
+            if (!connection && input.type === 'ethernet') {
+                connection = await this.ensureEthernetConnection(input.iface);
+            }
+            if (!connection) {
+                return { success: false, message: 'No editable NetworkManager profile found for this interface' };
+            }
+
+            const dnsList = Array.isArray(input.dns)
+                ? input.dns.map(item => `${item}`.trim()).filter(Boolean)
+                : NetworkSettings.parseList(input.dns || '');
+            const invalidDns = dnsList.find(dns => !isIPv4(dns));
+            if (invalidDns) {
+                return { success: false, message: `Invalid DNS server: ${invalidDns}` };
+            }
+
+            if (input.dhcp) {
+                await this.execFileAsync(
+                    'nmcli',
+                    [
+                        'connection',
+                        'modify',
+                        connection,
+                        'ipv4.method',
+                        'auto',
+                        'ipv4.addresses',
+                        '',
+                        'ipv4.gateway',
+                        '',
+                        'ipv4.dns',
+                        dnsList.join(','),
+                        'ipv4.ignore-auto-dns',
+                        dnsList.length ? 'yes' : 'no',
+                    ],
+                    { sudo: true },
+                );
+            } else {
+                const ip4 = (input.ip4 || '').trim();
+                const prefix = NetworkSettings.normalizeIpv4Prefix(input.ip4subnet || '');
+                const gateway = (input.gateway || '').trim();
+
+                if (!isIPv4(ip4)) {
+                    return { success: false, message: 'Invalid IPv4 address' };
+                }
+                if (prefix === null) {
+                    return { success: false, message: 'Invalid subnet mask' };
+                }
+                if (gateway && !isIPv4(gateway)) {
+                    return { success: false, message: 'Invalid gateway address' };
+                }
+
+                await this.execFileAsync(
+                    'nmcli',
+                    [
+                        'connection',
+                        'modify',
+                        connection,
+                        'ipv4.method',
+                        'manual',
+                        'ipv4.addresses',
+                        `${ip4}/${prefix}`,
+                        'ipv4.gateway',
+                        gateway,
+                        'ipv4.dns',
+                        dnsList.join(','),
+                        'ipv4.ignore-auto-dns',
+                        'no',
+                    ],
+                    { sudo: true },
+                );
+            }
+
+            this.scheduleConnectionApply(input.iface, connection);
+            return {
+                success: true,
+                message: 'Network settings saved. The connection will be reapplied shortly.',
+                connection,
+                scheduled: true,
+            };
+        } catch (e) {
+            return { success: false, message: `Cannot save network settings: ${e}` };
         }
     }
 }


### PR DESCRIPTION
This PR extends the adapter so it can manage not only wireless settings, but also Ethernet network settings.

What was changed
Added support for configuring Ethernet interfaces
Added switching between DHCP and static IPv4
Added fields for IP address, subnet/prefix, gateway, and DNS
Improved handling of NetworkManager profiles for Ethernet devices
Extended the admin UI to edit network settings directly
Refactored command execution to make backend handling safer and more robust
Result

The adapter can now be used to fully manage the device's network settings, including assigning a fixed IP address when needed.

<img width="1399" height="797" alt="Screenshot 2026-04-14 223346" src="https://github.com/user-attachments/assets/2b2b4027-ed68-4532-b8ee-b13398b8d0c0" />
<img width="1732" height="849" alt="Screenshot 2026-04-14 223502" src="https://github.com/user-attachments/assets/bfd19739-9168-4f7d-b960-bc898b98e8e6" />
